### PR TITLE
test: enable forge test github action by revise workflow file

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
+          version: nightly-f625d0fa7c51e65b4bf1e8f7931cd1c6e2e285e9
 
       - name: Run Forge build
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,13 @@
 name: test
 
-on: workflow_dispatch
+on: 
+  pull_request:
+  push:
+    branches:
+      - main
+      - release/**
+    tags:
+      - "*"
 
 env:
   FOUNDRY_PROFILE: ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: stable
+          version: nightly-f625d0fa7c51e65b4bf1e8f7931cd1c6e2e285e9
 
       - name: Run Forge build
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,8 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
+          # replace nightly because latest nightly release has some breaking changes that result in test failures
+          # this is a previous recent nightly release that should work
           version: nightly-f625d0fa7c51e65b4bf1e8f7931cd1c6e2e285e9
 
       - name: Run Forge build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,9 +27,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          # replace nightly because latest nightly release has some breaking changes that result in test failures
-          # this is a previous recent nightly release that should work
-          version: nightly-f625d0fa7c51e65b4bf1e8f7931cd1c6e2e285e9
+          version: stable
 
       - name: Run Forge build
         run: |
@@ -41,3 +39,16 @@ jobs:
         run: |
           forge test -vvv
         id: test
+
+      - name: Add comment on failure
+        if: failure()
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'The GitHub Actions workflow has failed. Please check the logs for more details.'
+            })


### PR DESCRIPTION
## Description

action that runs `forge test` against committed code of pull request is not enabled. we could revise exisiting test.yml file to activate it

according to my test in my personal repo, this should work: https://github.com/adu-web3/exocore-contracts/actions/runs/9346017944/job/25719994787?pr=2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated GitHub Actions workflow triggers to run on pull requests and pushes to specific branches and tags.
  - Changed Foundry installation version from nightly to stable to avoid test failures.
  - Added a step to automatically comment on pull requests when the GitHub Actions workflow fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->