### PR TITLE
feat: Add a deposit-then-delegate function

### DIFF
--- a/src/core/BaseRestakingController.sol
+++ b/src/core/BaseRestakingController.sol
@@ -70,8 +70,9 @@ abstract contract BaseRestakingController is
     ) internal {
         if (token != VIRTUAL_STAKED_ETH_ADDRESS) {
             IVault vault = _getVault(token);
-            if (action == Action.REQUEST_DEPOSIT) {
-                vault.deposit(sender, amount); // Logic specific to the REQUEST_DEPOSIT action.
+            if ((action == Action.REQUEST_DEPOSIT) || (action == Action.REQUEST_DEPOSIT_THEN_DELEGATE_TO)) {
+                // if there is a deposit, we should transfer the tokens to the vault.
+                vault.deposit(sender, amount);
             }
         }
         outboundNonce++;

--- a/src/core/Bootstrap.sol
+++ b/src/core/Bootstrap.sol
@@ -72,7 +72,7 @@ contract Bootstrap is
             _deployVault(underlyingToken);
         }
 
-        _whiteListFunctionSelectors[Action.MARK_BOOTSTRAP] = this.markBootstrapped.selector;
+        _whiteListFunctionSelectors[Action.REQUEST_MARK_BOOTSTRAP] = this.markBootstrapped.selector;
 
         customProxyAdmin = customProxyAdmin_;
         bootstrapped = false;

--- a/src/core/Bootstrap.sol
+++ b/src/core/Bootstrap.sol
@@ -7,6 +7,7 @@ import {ITransparentUpgradeableProxy} from
 import {OwnableUpgradeable} from "@openzeppelin-upgradeable/contracts/access/OwnableUpgradeable.sol";
 import {Initializable} from "@openzeppelin-upgradeable/contracts/proxy/utils/Initializable.sol";
 import {PausableUpgradeable} from "@openzeppelin-upgradeable/contracts/utils/PausableUpgradeable.sol";
+import {ReentrancyGuardUpgradeable} from "@openzeppelin-upgradeable/contracts/utils/ReentrancyGuardUpgradeable.sol";
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 import {OAppCoreUpgradeable} from "../lzApp/OAppCoreUpgradeable.sol";
@@ -28,6 +29,7 @@ contract Bootstrap is
     Initializable,
     PausableUpgradeable,
     OwnableUpgradeable,
+    ReentrancyGuardUpgradeable,
     ILSTRestakingController,
     IOperatorRegistry,
     BootstrapLzReceiver
@@ -156,7 +158,7 @@ contract Bootstrap is
     }
 
     // implementation of ITokenWhitelister
-    function addWhitelistToken(address _token) public override beforeLocked onlyOwner whenNotPaused {
+    function addWhitelistToken(address _token) public override beforeLocked onlyOwner whenNotPaused nonReentrant {
         super.addWhitelistToken(_token);
     }
 
@@ -314,26 +316,32 @@ contract Bootstrap is
         whenNotPaused
         isTokenWhitelisted(token)
         isValidAmount(amount)
+        nonReentrant // interacts with Vault
     {
-        IVault vault = _getVault(token);
-        vault.deposit(msg.sender, amount);
+        _deposit(msg.sender, token, amount);
+    }
 
-        if (!isDepositor[msg.sender]) {
-            isDepositor[msg.sender] = true;
-            depositors.push(msg.sender);
+    // _deposit is the internal function that does the work
+    function _deposit(address depositor, address token, uint256 amount) internal {
+        IVault vault = _getVault(token);
+        vault.deposit(depositor, amount);
+
+        if (!isDepositor[depositor]) {
+            isDepositor[depositor] = true;
+            depositors.push(depositor);
         }
 
         // staker_asset.go duplicate here. the duplication is required (and not simply inferred
         // from vault) because the vault is not altered by the gateway in response to
         // delegations or undelegations. hence, this is not something we can do either.
-        totalDepositAmounts[msg.sender][token] += amount;
-        withdrawableAmounts[msg.sender][token] += amount;
+        totalDepositAmounts[depositor][token] += amount;
+        withdrawableAmounts[depositor][token] += amount;
         depositsByToken[token] += amount;
 
         // afterReceiveDepositResponse stores the TotalDepositAmount in the principle.
-        vault.updatePrincipleBalance(msg.sender, totalDepositAmounts[msg.sender][token]);
+        vault.updatePrincipleBalance(depositor, totalDepositAmounts[depositor][token]);
 
-        emit DepositResult(true, token, msg.sender, amount);
+        emit DepositResult(true, token, depositor, amount);
     }
 
     // implementation of ILSTRestakingController
@@ -346,24 +354,30 @@ contract Bootstrap is
         whenNotPaused
         isTokenWhitelisted(token)
         isValidAmount(amount)
+        nonReentrant // interacts with Vault
     {
+        _withdraw(msg.sender, token, amount);
+    }
+
+    // _withdraw is the internal function that does the actual work.
+    function _withdraw(address user, address token, uint256 amount) internal {
         IVault vault = _getVault(token);
 
-        uint256 deposited = totalDepositAmounts[msg.sender][token];
+        uint256 deposited = totalDepositAmounts[user][token];
         require(deposited >= amount, "Bootstrap: insufficient deposited balance");
-        uint256 withdrawable = withdrawableAmounts[msg.sender][token];
+        uint256 withdrawable = withdrawableAmounts[user][token];
         require(withdrawable >= amount, "Bootstrap: insufficient withdrawable balance");
 
         // when the withdraw precompile is called, it does these things.
-        totalDepositAmounts[msg.sender][token] -= amount;
-        withdrawableAmounts[msg.sender][token] -= amount;
+        totalDepositAmounts[user][token] -= amount;
+        withdrawableAmounts[user][token] -= amount;
         depositsByToken[token] -= amount;
 
         // afterReceiveWithdrawPrincipleResponse
-        vault.updatePrincipleBalance(msg.sender, totalDepositAmounts[msg.sender][token]);
-        vault.updateWithdrawableBalance(msg.sender, amount, 0);
+        vault.updatePrincipleBalance(user, totalDepositAmounts[user][token]);
+        vault.updateWithdrawableBalance(user, amount, 0);
 
-        emit WithdrawPrincipleResult(true, token, msg.sender, amount);
+        emit WithdrawPrincipleResult(true, token, user, amount);
     }
 
     // implementation of ILSTRestakingController
@@ -380,6 +394,7 @@ contract Bootstrap is
         whenNotPaused
         isTokenWhitelisted(token)
         isValidAmount(amount)
+        nonReentrant // because it interacts with vault
     {
         IVault vault = _getVault(token);
         vault.withdraw(msg.sender, recipient, amount);
@@ -395,7 +410,12 @@ contract Bootstrap is
         isTokenWhitelisted(token)
         isValidAmount(amount)
         isValidBech32Address(operator)
+    // does not need a reentrancy guard
     {
+        _delegateTo(msg.sender, operator, token, amount);
+    }
+
+    function _delegateTo(address user, string calldata operator, address token, uint256 amount) internal {
         require(msg.value == 0, "Bootstrap: no ether required for delegation");
         // check that operator is registered
         require(bytes(operators[operator].name).length != 0, "Operator does not exist");
@@ -404,11 +424,11 @@ contract Bootstrap is
         // now check amounts.
         uint256 withdrawable = withdrawableAmounts[msg.sender][token];
         require(withdrawable >= amount, "Bootstrap: insufficient withdrawable balance");
-        delegations[msg.sender][operator][token] += amount;
+        delegations[user][operator][token] += amount;
         delegationsByOperator[operator][token] += amount;
-        withdrawableAmounts[msg.sender][token] -= amount;
+        withdrawableAmounts[user][token] -= amount;
 
-        emit DelegateResult(true, msg.sender, operator, token, amount);
+        emit DelegateResult(true, user, operator, token, amount);
     }
 
     // implementation of ILSTRestakingController
@@ -421,21 +441,26 @@ contract Bootstrap is
         isTokenWhitelisted(token)
         isValidAmount(amount)
         isValidBech32Address(operator)
+    // does not need a reentrancy guard
     {
+        _undelegateFrom(msg.sender, operator, token, amount);
+    }
+
+    function _undelegateFrom(address user, string calldata operator, address token, uint256 amount) internal {
         require(msg.value == 0, "Bootstrap: no ether required for undelegation");
         // check that operator is registered
         require(bytes(operators[operator].name).length != 0, "Operator does not exist");
         // operator can't be frozen and amount can't be negative
         // asset validity has been checked.
         // now check amounts.
-        uint256 delegated = delegations[msg.sender][operator][token];
+        uint256 delegated = delegations[user][operator][token];
         require(delegated >= amount, "Bootstrap: insufficient delegated balance");
         // the undelegation is released immediately since it is not at stake yet.
-        delegations[msg.sender][operator][token] -= amount;
+        delegations[user][operator][token] -= amount;
         delegationsByOperator[operator][token] -= amount;
-        withdrawableAmounts[msg.sender][token] += amount;
+        withdrawableAmounts[user][token] += amount;
 
-        emit UndelegateResult(true, msg.sender, operator, token, amount);
+        emit UndelegateResult(true, user, operator, token, amount);
     }
 
     // implementation of ILSTRestakingController
@@ -448,9 +473,10 @@ contract Bootstrap is
         isTokenWhitelisted(token)
         isValidAmount(amount)
         isValidBech32Address(operator)
+        nonReentrant // because it interacts with vault in deposit
     {
-        this.deposit(token, amount);
-        this.delegateTo(operator, token, amount);
+        _deposit(msg.sender, token, amount);
+        _delegateTo(msg.sender, operator, token, amount);
     }
 
     /**

--- a/src/core/ClientChainGateway.sol
+++ b/src/core/ClientChainGateway.sol
@@ -92,6 +92,8 @@ contract ClientChainGateway is
         _registeredResponseHooks[Action.REQUEST_UNDELEGATE_FROM] = this.afterReceiveUndelegateResponse.selector;
         _registeredResponseHooks[Action.REQUEST_WITHDRAW_REWARD_FROM_EXOCORE] =
             this.afterReceiveWithdrawRewardResponse.selector;
+        _registeredResponseHooks[Action.REQUEST_DEPOSIT_THEN_DELEGATE_TO] =
+            this.afterReceiveDepositThenDelegateToResponse.selector;
 
         bootstrapped = true;
 

--- a/src/core/ClientChainGateway.sol
+++ b/src/core/ClientChainGateway.sol
@@ -104,7 +104,7 @@ contract ClientChainGateway is
 
     function _clearBootstrapData() internal {
         // mandatory to clear!
-        delete _whiteListFunctionSelectors[Action.MARK_BOOTSTRAP];
+        delete _whiteListFunctionSelectors[Action.REQUEST_MARK_BOOTSTRAP];
         // the set below is recommended to clear, so that any possibilities of upgrades
         // can then be removed.
         delete customProxyAdmin;

--- a/src/core/ExocoreGateway.sol
+++ b/src/core/ExocoreGateway.sol
@@ -230,8 +230,8 @@ contract ExocoreGateway is
 
         bytes calldata token = payload[:32];
         bytes calldata depositor = payload[32:64];
-        uint256 amount = uint256(bytes32(payload[64:96]));
-        bytes calldata operator = payload[96:138];
+        bytes calldata operator = payload[64:106];
+        uint256 amount = uint256(bytes32(payload[106:138]));
 
         // while some of the code from requestDeposit and requestDelegateTo is duplicated here,
         // it is done intentionally to work around Solidity's limitations with regards to
@@ -243,7 +243,7 @@ contract ExocoreGateway is
         }
         try DELEGATION_CONTRACT.delegateToThroughClientChain(srcChainId, lzNonce, token, depositor, operator, amount)
         returns (bool delegateSuccess) {
-            _sendInterchainMsg(srcChainId, Action.RESPOND, abi.encodePacked(lzNonce, true, updatedBalance));
+            _sendInterchainMsg(srcChainId, Action.RESPOND, abi.encodePacked(lzNonce, delegateSuccess, updatedBalance));
         } catch {
             emit ExocorePrecompileError(DELEGATION_PRECOMPILE_ADDRESS, lzNonce);
             _sendInterchainMsg(srcChainId, Action.RESPOND, abi.encodePacked(lzNonce, false, updatedBalance));

--- a/src/core/ExocoreGateway.sol
+++ b/src/core/ExocoreGateway.sol
@@ -237,6 +237,8 @@ contract ExocoreGateway is
         // while some of the code from requestDeposit and requestDelegateTo is duplicated here,
         // it is done intentionally to work around Solidity's limitations with regards to
         // function calls, error handling and indexing the return data of memory type.
+        // for example, you cannot index a bytes memory result from the requestDepositTo call,
+        // if you were to modify it to return bytes and then process them here.
 
         (bool success, uint256 updatedBalance) = DEPOSIT_CONTRACT.depositTo(srcChainId, token, depositor, amount);
         if (!success) {

--- a/src/core/ExocoreGateway.sol
+++ b/src/core/ExocoreGateway.sol
@@ -85,7 +85,7 @@ contract ExocoreGateway is
         for (uint256 i = 0; i < clientChainIds.length; i++) {
             uint16 clientChainId = clientChainIds[i];
             if (!chainToBootstrapped[clientChainId]) {
-                _sendInterchainMsg(uint32(clientChainId), Action.MARK_BOOTSTRAP, "");
+                _sendInterchainMsg(uint32(clientChainId), Action.REQUEST_MARK_BOOTSTRAP, "");
                 // TODO: should this be marked only upon receiving a response?
                 chainToBootstrapped[clientChainId] = true;
             }

--- a/src/core/ExocoreGateway.sol
+++ b/src/core/ExocoreGateway.sol
@@ -67,7 +67,8 @@ contract ExocoreGateway is
         _whiteListFunctionSelectors[Action.REQUEST_WITHDRAW_PRINCIPLE_FROM_EXOCORE] =
             this.requestWithdrawPrinciple.selector;
         _whiteListFunctionSelectors[Action.REQUEST_WITHDRAW_REWARD_FROM_EXOCORE] = this.requestWithdrawReward.selector;
-        _whiteListFunctionSelectors[Action.REQUEST_DEPOSIT_THEN_DELEGATE_TO] = this.requestDepositThenDelegateTo.selector;
+        _whiteListFunctionSelectors[Action.REQUEST_DEPOSIT_THEN_DELEGATE_TO] =
+            this.requestDepositThenDelegateTo.selector;
     }
 
     // TODO: call this function automatically, either within the initializer (which requires
@@ -237,7 +238,7 @@ contract ExocoreGateway is
         // it is done intentionally to work around Solidity's limitations with regards to
         // function calls, error handling and indexing the return data of memory type.
 
-        (bool success, uint256 updatedBalance) =  DEPOSIT_CONTRACT.depositTo(srcChainId, token, depositor, amount);
+        (bool success, uint256 updatedBalance) = DEPOSIT_CONTRACT.depositTo(srcChainId, token, depositor, amount);
         if (!success) {
             revert DepositRequestShouldNotFail(srcChainId, lzNonce);
         }

--- a/src/core/LSTRestakingController.sol
+++ b/src/core/LSTRestakingController.sol
@@ -37,4 +37,17 @@ abstract contract LSTRestakingController is PausableUpgradeable, ILSTRestakingCo
         _processRequest(token, msg.sender, rewardAmount, Action.REQUEST_WITHDRAW_REWARD_FROM_EXOCORE, "");
     }
 
+    // implementation of ILSTRestakingController
+    function depositThenDelegateTo(address token, uint256 amount, string calldata operator)
+        external
+        payable
+        override
+        isTokenWhitelisted(token)
+        isValidAmount(amount)
+        isValidBech32Address(operator)
+        whenNotPaused
+    {
+        _processRequest(token, msg.sender, amount, Action.REQUEST_DEPOSIT_THEN_DELEGATE_TO, operator);
+    }
+
 }

--- a/src/interfaces/ILSTRestakingController.sol
+++ b/src/interfaces/ILSTRestakingController.sol
@@ -48,7 +48,6 @@ interface ILSTRestakingController is IBaseRestakingController {
     function withdrawRewardFromExocore(address token, uint256 rewardAmount) external payable;
 
     /**
-     * 8
      * @notice Client chain users can call this function to deposit and then delegate to specific node operator.
      * @dev This function should:
      * 1) lock the @param amount of @param token into vault.

--- a/src/interfaces/ILSTRestakingController.sol
+++ b/src/interfaces/ILSTRestakingController.sol
@@ -47,4 +47,18 @@ interface ILSTRestakingController is IBaseRestakingController {
 
     function withdrawRewardFromExocore(address token, uint256 rewardAmount) external payable;
 
+    /**8
+     * @notice Client chain users can call this function to deposit and then delegate to specific node operator.
+     * @dev This function should:
+     * 1) lock the @param amount of @param token into vault.
+     * 2) ask Exocore validator set to account for the deposited @param amount of @param token.
+     * 3) ask Exocore validator set to delegate the deposited @param amount of @param token to specific node operator.
+     * Deposit should always be considered successful on Exocore chain side.
+     * Delegate can potentially fail, for example, if the node operator is not registered in Exocore.
+     * @param token - The address of specific token that the user wants to deposit and delegate.
+     * @param amount - The amount of @param token that the user wants to deposit and delegate.
+     * @param operator - The address of a registered node operator that the user wants to delegate to.
+     */
+    function depositThenDelegateTo(address token, uint256 amount, string calldata operator) external payable;
+
 }

--- a/src/interfaces/ILSTRestakingController.sol
+++ b/src/interfaces/ILSTRestakingController.sol
@@ -47,7 +47,8 @@ interface ILSTRestakingController is IBaseRestakingController {
 
     function withdrawRewardFromExocore(address token, uint256 rewardAmount) external payable;
 
-    /**8
+    /**
+     * 8
      * @notice Client chain users can call this function to deposit and then delegate to specific node operator.
      * @dev This function should:
      * 1) lock the @param amount of @param token into vault.

--- a/src/storage/BootstrapStorage.sol
+++ b/src/storage/BootstrapStorage.sol
@@ -318,6 +318,19 @@ contract BootstrapStorage is GatewayStorage, ITokenWhitelister {
     );
 
     /**
+     * @notice Emitted when a deposit + delegation is made.
+     * @dev This event is triggered whenever a delegator deposits and then delegates tokens to an operator.
+     * @param delegateSuccess Whether the delegation succeeded (deposits always succeed!).
+     * @param delegator The address of the delegator, on this chain.
+     * @param delegatee The Exocore address of the operator.
+     * @param token The address of the token being delegated, on this chain.
+     * @param amount The amount of the token delegated.
+     */
+    event DepositThenDelegateResult(
+        bool indexed delegateSuccess, address indexed delegator, string indexed delegatee, address token, uint256 amount
+    );
+
+    /**
      * @notice Emitted after the Exocore chain is bootstrapped.
      * @dev This event is triggered after the Exocore chain is bootstrapped, indicating that
      * the contract has successfully transitioned to the Client Chain Gateway logic. Exocore

--- a/src/storage/BootstrapStorage.sol
+++ b/src/storage/BootstrapStorage.sol
@@ -324,10 +324,14 @@ contract BootstrapStorage is GatewayStorage, ITokenWhitelister {
      * @param delegator The address of the delegator, on this chain.
      * @param delegatee The Exocore address of the operator.
      * @param token The address of the token being delegated, on this chain.
-     * @param amount The amount of the token delegated.
+     * @param delegatedAmount The amount of the token delegated.
      */
     event DepositThenDelegateResult(
-        bool indexed delegateSuccess, address indexed delegator, string indexed delegatee, address token, uint256 amount
+        bool indexed delegateSuccess,
+        address indexed delegator,
+        string indexed delegatee,
+        address token,
+        uint256 delegatedAmount
     );
 
     /**

--- a/src/storage/ExocoreGatewayStorage.sol
+++ b/src/storage/ExocoreGatewayStorage.sol
@@ -14,6 +14,8 @@ contract ExocoreGatewayStorage is GatewayStorage {
     uint256 internal constant WITHDRAW_PRINCIPLE_REQUEST_LENGTH = 96;
     // bytes32 token + bytes32 withdrawer + uint256 amount
     uint256 internal constant CLAIM_REWARD_REQUEST_LENGTH = 96;
+    // bytes32 token + bytes32 delegator + bytes(42) operator + uint256 amount
+    uint256 internal constant DEPOSIT_THEN_DELEGATE_REQUEST_LENGTH = DELEGATE_REQUEST_LENGTH;
 
     uint128 internal constant DESTINATION_GAS_LIMIT = 500_000;
     uint128 internal constant DESTINATION_MSG_VALUE = 0;

--- a/src/storage/GatewayStorage.sol
+++ b/src/storage/GatewayStorage.sol
@@ -8,11 +8,10 @@ contract GatewayStorage {
         REQUEST_WITHDRAW_REWARD_FROM_EXOCORE,
         REQUEST_DELEGATE_TO,
         REQUEST_UNDELEGATE_FROM,
+        REQUEST_DEPOSIT_THEN_DELEGATE_TO,
+        REQUEST_MARK_BOOTSTRAP,
         RESPOND,
         UPDATE_USERS_BALANCES,
-        MARK_BOOTSTRAP,
-        // TODO: can this be moved upwards safely without impacting the upgradeability?
-        REQUEST_DEPOSIT_THEN_DELEGATE_TO
     }
 
     mapping(Action => bytes4) public _whiteListFunctionSelectors;

--- a/src/storage/GatewayStorage.sol
+++ b/src/storage/GatewayStorage.sol
@@ -10,7 +10,9 @@ contract GatewayStorage {
         REQUEST_UNDELEGATE_FROM,
         RESPOND,
         UPDATE_USERS_BALANCES,
-        MARK_BOOTSTRAP
+        MARK_BOOTSTRAP,
+        // TODO: can this be moved upwards safely without impacting the upgradeability?
+        REQUEST_DEPOSIT_THEN_DELEGATE_TO
     }
 
     mapping(Action => bytes4) public _whiteListFunctionSelectors;

--- a/src/storage/GatewayStorage.sol
+++ b/src/storage/GatewayStorage.sol
@@ -11,7 +11,7 @@ contract GatewayStorage {
         REQUEST_DEPOSIT_THEN_DELEGATE_TO,
         REQUEST_MARK_BOOTSTRAP,
         RESPOND,
-        UPDATE_USERS_BALANCES,
+        UPDATE_USERS_BALANCES
     }
 
     mapping(Action => bytes4) public _whiteListFunctionSelectors;

--- a/test/foundry/Bootstrap.t.sol
+++ b/test/foundry/Bootstrap.t.sol
@@ -844,7 +844,9 @@ contract BootstrapTest is Test {
         test12_MarkBootstrapped();
         vm.startPrank(address(clientChainLzEndpoint));
         vm.expectRevert(
-            abi.encodeWithSelector(GatewayStorage.UnsupportedRequest.selector, GatewayStorage.Action.REQUEST_MARK_BOOTSTRAP)
+            abi.encodeWithSelector(
+                GatewayStorage.UnsupportedRequest.selector, GatewayStorage.Action.REQUEST_MARK_BOOTSTRAP
+            )
         );
         bootstrap.lzReceive(
             Origin(exocoreChainId, bytes32(bytes20(undeployedExocoreGateway)), uint64(2)),

--- a/test/foundry/Bootstrap.t.sol
+++ b/test/foundry/Bootstrap.t.sol
@@ -814,7 +814,7 @@ contract BootstrapTest is Test {
             Origin(exocoreChainId, bytes32(bytes20(undeployedExocoreGateway)), uint64(1)),
             address(bootstrap),
             generateUID(1),
-            abi.encodePacked(GatewayStorage.Action.MARK_BOOTSTRAP, ""),
+            abi.encodePacked(GatewayStorage.Action.REQUEST_MARK_BOOTSTRAP, ""),
             bytes("")
         );
         vm.stopPrank();
@@ -833,7 +833,7 @@ contract BootstrapTest is Test {
             Origin(exocoreChainId, bytes32(bytes20(undeployedExocoreGateway)), uint64(1)),
             address(bootstrap),
             generateUID(1),
-            abi.encodePacked(GatewayStorage.Action.MARK_BOOTSTRAP, ""),
+            abi.encodePacked(GatewayStorage.Action.REQUEST_MARK_BOOTSTRAP, ""),
             bytes("")
         );
         vm.stopPrank();
@@ -844,12 +844,12 @@ contract BootstrapTest is Test {
         test12_MarkBootstrapped();
         vm.startPrank(address(clientChainLzEndpoint));
         vm.expectRevert(
-            abi.encodeWithSelector(GatewayStorage.UnsupportedRequest.selector, GatewayStorage.Action.MARK_BOOTSTRAP)
+            abi.encodeWithSelector(GatewayStorage.UnsupportedRequest.selector, GatewayStorage.Action.REQUEST_MARK_BOOTSTRAP)
         );
         bootstrap.lzReceive(
             Origin(exocoreChainId, bytes32(bytes20(undeployedExocoreGateway)), uint64(2)),
             generateUID(1),
-            abi.encodePacked(GatewayStorage.Action.MARK_BOOTSTRAP, ""),
+            abi.encodePacked(GatewayStorage.Action.REQUEST_MARK_BOOTSTRAP, ""),
             address(0),
             bytes("")
         );

--- a/test/foundry/Bootstrap.t.sol
+++ b/test/foundry/Bootstrap.t.sol
@@ -427,8 +427,8 @@ contract BootstrapTest is Test {
         uint256 deposited = bootstrap.totalDepositAmounts(addrs[0], address(myToken));
         assertTrue(deposited == amounts[0]);
 
-        uint256 delegated = bootstrap.delegations(addrs[0], "exo13hasr43vvq8v44xpzh0l6yuym4kca98f87j7ac",
-        address(myToken));
+        uint256 delegated =
+            bootstrap.delegations(addrs[0], "exo13hasr43vvq8v44xpzh0l6yuym4kca98f87j7ac", address(myToken));
         assertTrue(delegated == amounts[0]);
     }
 

--- a/test/foundry/Bootstrap.t.sol
+++ b/test/foundry/Bootstrap.t.sol
@@ -414,6 +414,24 @@ contract BootstrapTest is Test {
         vm.stopPrank();
     }
 
+    function test04_DepositThenDelegate() public {
+        // since deposit and delegate are already tested, we will just do a simple success
+        // check here to ensure the reentrancy modifier works.
+        test03_RegisterOperator();
+        vm.startPrank(addrs[0]);
+        IVault vault = IVault(bootstrap.tokenToVault(address(myToken)));
+        myToken.approve(address(vault), amounts[0]);
+        bootstrap.depositThenDelegateTo(address(myToken), amounts[0], "exo13hasr43vvq8v44xpzh0l6yuym4kca98f87j7ac");
+        vm.stopPrank();
+
+        uint256 deposited = bootstrap.totalDepositAmounts(addrs[0], address(myToken));
+        assertTrue(deposited == amounts[0]);
+
+        uint256 delegated = bootstrap.delegations(addrs[0], "exo13hasr43vvq8v44xpzh0l6yuym4kca98f87j7ac",
+        address(myToken));
+        assertTrue(delegated == amounts[0]);
+    }
+
     function test05_ReplaceKey() public {
         IOperatorRegistry.Commission memory commission = IOperatorRegistry.Commission(0, 1e18, 1e18);
         // Register operator

--- a/test/foundry/Delegation.t.sol
+++ b/test/foundry/Delegation.t.sol
@@ -288,16 +288,4 @@ contract DelegateTest is ExocoreDeployer {
         vm.stopPrank();
     }
 
-    function generateUID(uint64 nonce, bool fromClientChainToExocore) internal view returns (bytes32 uid) {
-        if (fromClientChainToExocore) {
-            uid = GUID.generate(
-                nonce, clientChainId, address(clientGateway), exocoreChainId, address(exocoreGateway).toBytes32()
-            );
-        } else {
-            uid = GUID.generate(
-                nonce, exocoreChainId, address(exocoreGateway), clientChainId, address(clientGateway).toBytes32()
-            );
-        }
-    }
-
 }

--- a/test/foundry/DepositThenDelegateTo.t.sol
+++ b/test/foundry/DepositThenDelegateTo.t.sol
@@ -48,16 +48,15 @@ contract DepositThenDelegateToTest is ExocoreDeployer {
         uint64 lzNonce = 1;
         uint256 delegateAmount = 10_000;
 
-        (bytes32 requestId, bytes memory requestPayload) = _testRequest(delegator, operatorAddress, lzNonce, delegateAmount);
+        (bytes32 requestId, bytes memory requestPayload) =
+            _testRequest(delegator, operatorAddress, lzNonce, delegateAmount);
         _testResponse(requestId, requestPayload, delegator, relayer, operatorAddress, lzNonce, delegateAmount);
     }
 
-    function _testRequest(
-        address delegator,
-        string memory operatorAddress,
-        uint64 lzNonce,
-        uint256 delegateAmount
-    ) private returns (bytes32 requestId, bytes memory requestPayload) {
+    function _testRequest(address delegator, string memory operatorAddress, uint64 lzNonce, uint256 delegateAmount)
+        private
+        returns (bytes32 requestId, bytes memory requestPayload)
+    {
         requestPayload = abi.encodePacked(
             GatewayStorage.Action.REQUEST_DEPOSIT_THEN_DELEGATE_TO,
             abi.encodePacked(bytes32(bytes20(address(restakeToken)))),
@@ -70,18 +69,16 @@ contract DepositThenDelegateToTest is ExocoreDeployer {
 
         vm.expectEmit(address(clientChainLzEndpoint));
         emit NewPacket(
-            exocoreChainId,
-            address(clientGateway),
-            address(exocoreGateway).toBytes32(),
-            lzNonce,
-            requestPayload
+            exocoreChainId, address(clientGateway), address(exocoreGateway).toBytes32(), lzNonce, requestPayload
         );
 
         vm.expectEmit(address(clientGateway));
         emit MessageSent(GatewayStorage.Action.REQUEST_DEPOSIT_THEN_DELEGATE_TO, requestId, lzNonce, requestNativeFee);
 
         vm.startPrank(delegator);
-        clientGateway.depositThenDelegateTo{value: requestNativeFee}(address(restakeToken), delegateAmount, operatorAddress);
+        clientGateway.depositThenDelegateTo{value: requestNativeFee}(
+            address(restakeToken), delegateAmount, operatorAddress
+        );
         vm.stopPrank();
     }
 

--- a/test/foundry/DepositThenDelegateTo.t.sol
+++ b/test/foundry/DepositThenDelegateTo.t.sol
@@ -24,7 +24,11 @@ contract DepositThenDelegateToTest is ExocoreDeployer {
 
     // ClientChainGateway emits this when receiving the response
     event DepositThenDelegateResult(
-        bool indexed success, address indexed delegator, string indexed delegatee, address token, uint256 amount
+        bool indexed delegateSuccess,
+        address indexed delegator,
+        string indexed delegatee,
+        address token,
+        uint256 delegatedAmount
     );
 
     // emitted by the mock delegation contract

--- a/test/foundry/DepositThenDelegateTo.t.sol
+++ b/test/foundry/DepositThenDelegateTo.t.sol
@@ -1,0 +1,155 @@
+pragma solidity ^0.8.19;
+
+import "../../src/core/ExocoreGateway.sol";
+
+import "../../src/interfaces/precompiles/IDelegation.sol";
+import "../../src/storage/GatewayStorage.sol";
+import "../mocks/DelegationMock.sol";
+import "./ExocoreDeployer.t.sol";
+
+import {OptionsBuilder} from "@layerzero-v2/oapp/contracts/oapp/libs/OptionsBuilder.sol";
+import "@layerzero-v2/protocol/contracts/libs/AddressCast.sol";
+import "@layerzerolabs/lz-evm-protocol-v2/contracts/libs/GUID.sol";
+import "forge-std/Test.sol";
+
+import "forge-std/console.sol";
+
+contract DepositThenDelegateToTest is ExocoreDeployer {
+
+    using AddressCast for address;
+
+    // layer zero events
+    event NewPacket(uint32, address, bytes32, uint64, bytes);
+    event MessageSent(GatewayStorage.Action indexed act, bytes32 packetId, uint64 nonce, uint256 nativeFee);
+
+    // ClientChainGateway emits this when receiving the response
+    event DepositThenDelegateResult(
+        bool indexed success, address indexed delegator, string indexed delegatee, address token, uint256 amount
+    );
+
+    // emitted by the mock delegation contract
+    event DelegateRequestProcessed(
+        uint32 clientChainLzId,
+        uint64 lzNonce,
+        bytes assetsAddress,
+        bytes stakerAddress,
+        string operatorAddr,
+        uint256 opAmount
+    );
+
+    function test_DepositThenDelegateTo() public {
+        address delegator = players[0].addr;
+        address relayer = players[1].addr;
+        string memory operatorAddress = "exo13hasr43vvq8v44xpzh0l6yuym4kca98f87j7ac";
+
+        deal(delegator, 1e22);
+        deal(address(exocoreGateway), 1e22);
+
+        uint64 lzNonce = 1;
+        uint256 delegateAmount = 10_000;
+
+        (bytes32 requestId, bytes memory requestPayload) = _testRequest(delegator, operatorAddress, lzNonce, delegateAmount);
+        _testResponse(requestId, requestPayload, delegator, relayer, operatorAddress, lzNonce, delegateAmount);
+    }
+
+    function _testRequest(
+        address delegator,
+        string memory operatorAddress,
+        uint64 lzNonce,
+        uint256 delegateAmount
+    ) private returns (bytes32 requestId, bytes memory requestPayload) {
+        requestPayload = abi.encodePacked(
+            GatewayStorage.Action.REQUEST_DEPOSIT_THEN_DELEGATE_TO,
+            abi.encodePacked(bytes32(bytes20(address(restakeToken)))),
+            abi.encodePacked(bytes32(bytes20(delegator))),
+            bytes(operatorAddress),
+            delegateAmount
+        );
+        uint256 requestNativeFee = clientGateway.quote(requestPayload);
+        requestId = generateUID(lzNonce, true);
+
+        vm.expectEmit(address(clientChainLzEndpoint));
+        emit NewPacket(
+            exocoreChainId,
+            address(clientGateway),
+            address(exocoreGateway).toBytes32(),
+            lzNonce,
+            requestPayload
+        );
+
+        vm.expectEmit(address(clientGateway));
+        emit MessageSent(GatewayStorage.Action.REQUEST_DEPOSIT_THEN_DELEGATE_TO, requestId, lzNonce, requestNativeFee);
+
+        vm.startPrank(delegator);
+        clientGateway.depositThenDelegateTo{value: requestNativeFee}(address(restakeToken), delegateAmount, operatorAddress);
+        vm.stopPrank();
+    }
+
+    // even though this function is called _testResponse, it also tests
+    // the receipt of an LZ packet on Exocore and then tests its response
+    function _testResponse(
+        bytes32 requestId,
+        bytes memory requestPayload,
+        address delegator,
+        address relayer,
+        string memory operatorAddress,
+        uint64 lzNonce,
+        uint256 delegateAmount
+    ) private {
+        bytes memory responsePayload = abi.encodePacked(GatewayStorage.Action.RESPOND, lzNonce, true, delegateAmount);
+        uint256 responseNativeFee = exocoreGateway.quote(clientChainId, responsePayload);
+        bytes32 responseId = generateUID(lzNonce, false);
+
+        // vm.expectEmit(DELEGATION_PRECOMPILE_ADDRESS);
+        // emit DelegateRequestProcessed(
+        //     clientChainId,
+        //     lzNonce,
+        //     abi.encodePacked(bytes32(bytes20(address(restakeToken)))),
+        //     abi.encodePacked(bytes32(bytes20(delegator))),
+        //     operatorAddress,
+        //     delegateAmount
+        // );
+
+        vm.expectEmit(true, true, true, true, address(exocoreLzEndpoint));
+        // nothing indexed here
+        emit NewPacket(
+            clientChainId,
+            address(exocoreGateway),
+            address(clientGateway).toBytes32(),
+            uint64(1), // outbound nonce not inbound, only equals because it's the first tx
+            responsePayload
+        );
+
+        vm.expectEmit(address(exocoreGateway));
+        emit MessageSent(GatewayStorage.Action.RESPOND, responseId, lzNonce, responseNativeFee);
+
+        vm.startPrank(relayer);
+        exocoreLzEndpoint.lzReceive(
+            Origin(clientChainId, address(clientGateway).toBytes32(), lzNonce),
+            address(exocoreGateway),
+            requestId,
+            requestPayload,
+            bytes("")
+        );
+        vm.stopPrank();
+
+        uint256 actualDelegateAmount = DelegationMock(DELEGATION_PRECOMPILE_ADDRESS).getDelegateAmount(
+            delegator, operatorAddress, clientChainId, address(restakeToken)
+        );
+        assertEq(actualDelegateAmount, delegateAmount);
+
+        vm.expectEmit(true, true, true, true, address(clientGateway));
+        emit DepositThenDelegateResult(true, delegator, operatorAddress, address(restakeToken), delegateAmount);
+
+        vm.startPrank(relayer);
+        clientChainLzEndpoint.lzReceive(
+            Origin(exocoreChainId, address(exocoreGateway).toBytes32(), lzNonce),
+            address(clientGateway),
+            responseId,
+            responsePayload,
+            bytes("")
+        );
+        vm.stopPrank();
+    }
+
+}

--- a/test/foundry/DepositThenDelegateTo.t.sol
+++ b/test/foundry/DepositThenDelegateTo.t.sol
@@ -158,8 +158,11 @@ contract DepositThenDelegateToTest is ExocoreDeployer {
         uint256 actualDepositAmount = DepositMock(DEPOSIT_PRECOMPILE_ADDRESS).principleBalances(
             clientChainId,
             // weirdly, the address(x).toBytes32() did not work here.
-            // that is because abi.encodePacked tightly packs the input
-            // and removes all zeroes.
+            // for reference, the results are
+            // addressOg = 0x0000000000000000000000000000000000000001
+            // toBytes32 = 0x0000000000000000000000000000000000000000000000000000000000000001
+            // abiEncode = 0x0000000000000000000000000000000000000001000000000000000000000000
+            // so, AddressCast left pads it while abi.encodePacked is right padding it.
             abi.encodePacked(bytes32(bytes20(address(restakeToken)))),
             abi.encodePacked(bytes32(bytes20(delegator)))
         );

--- a/test/foundry/DepositThenDelegateTo.t.sol
+++ b/test/foundry/DepositThenDelegateTo.t.sol
@@ -73,7 +73,8 @@ contract DepositThenDelegateToTest is ExocoreDeployer {
         private
         returns (bytes32 requestId, bytes memory requestPayload)
     {
-        uint256 beforeBalance = restakeToken.balanceOf(delegator);
+        uint256 beforeBalanceDelegator = restakeToken.balanceOf(delegator);
+        uint256 beforeBalanceVault = restakeToken.balanceOf(address(vault));
 
         requestPayload = abi.encodePacked(
             GatewayStorage.Action.REQUEST_DEPOSIT_THEN_DELEGATE_TO,
@@ -103,8 +104,10 @@ contract DepositThenDelegateToTest is ExocoreDeployer {
         vm.stopPrank();
 
         // check that the balance changed
-        uint256 afterBalance = restakeToken.balanceOf(delegator);
-        assertEq(afterBalance, beforeBalance - delegateAmount);
+        uint256 afterBalanceDelegator = restakeToken.balanceOf(delegator);
+        assertEq(afterBalanceDelegator, beforeBalanceDelegator - delegateAmount);
+        uint256 afterBalanceVault = restakeToken.balanceOf(address(vault));
+        assertEq(afterBalanceVault, beforeBalanceVault + delegateAmount);
     }
 
     // even though this function is called _testResponse, it also tests

--- a/test/foundry/DepositWithdrawPrinciple.t.sol
+++ b/test/foundry/DepositWithdrawPrinciple.t.sol
@@ -350,16 +350,4 @@ contract DepositWithdrawPrincipleTest is ExocoreDeployer {
         vm.stopPrank();
     }
 
-    function generateUID(uint64 nonce, bool fromClientChainToExocore) internal view returns (bytes32 uid) {
-        if (fromClientChainToExocore) {
-            uid = GUID.generate(
-                nonce, clientChainId, address(clientGateway), exocoreChainId, address(exocoreGateway).toBytes32()
-            );
-        } else {
-            uid = GUID.generate(
-                nonce, exocoreChainId, address(exocoreGateway), clientChainId, address(clientGateway).toBytes32()
-            );
-        }
-    }
-
 }

--- a/test/foundry/ExocoreDeployer.t.sol
+++ b/test/foundry/ExocoreDeployer.t.sol
@@ -276,4 +276,16 @@ contract ExocoreDeployer is Test {
         return vc[2].fromLittleEndianUint64();
     }
 
+    function generateUID(uint64 nonce, bool fromClientChainToExocore) internal view returns (bytes32 uid) {
+        if (fromClientChainToExocore) {
+            uid = GUID.generate(
+                nonce, clientChainId, address(clientGateway), exocoreChainId, address(exocoreGateway).toBytes32()
+            );
+        } else {
+            uid = GUID.generate(
+                nonce, exocoreChainId, address(exocoreGateway), clientChainId, address(clientGateway).toBytes32()
+            );
+        }
+    }
+
 }

--- a/test/foundry/WithdrawReward.t.sol
+++ b/test/foundry/WithdrawReward.t.sol
@@ -98,16 +98,4 @@ contract WithdrawRewardTest is ExocoreDeployer {
         );
     }
 
-    function generateUID(uint64 nonce, bool fromClientChainToExocore) internal view returns (bytes32 uid) {
-        if (fromClientChainToExocore) {
-            uid = GUID.generate(
-                nonce, clientChainId, address(clientGateway), exocoreChainId, address(exocoreGateway).toBytes32()
-            );
-        } else {
-            uid = GUID.generate(
-                nonce, exocoreChainId, address(exocoreGateway), clientChainId, address(clientGateway).toBytes32()
-            );
-        }
-    }
-
 }

--- a/test/mocks/DepositMock.sol
+++ b/test/mocks/DepositMock.sol
@@ -6,7 +6,7 @@ import "./WithdrawPrincipleMock.sol";
 
 contract DepositMock is IDeposit {
 
-    mapping(uint32 => mapping(bytes => mapping(bytes => uint256))) principleBalances;
+    mapping(uint32 => mapping(bytes => mapping(bytes => uint256))) public principleBalances;
 
     function depositTo(uint32 clientChainLzId, bytes memory assetsAddress, bytes memory stakerAddress, uint256 opAmount)
         external
@@ -29,6 +29,7 @@ contract DepositMock is IDeposit {
     ) external returns (bool success, uint256 latestAssetState) {
         require(opAmount <= principleBalances[clientChainLzId][assetsAddress][withdrawer], "withdraw amount overflow");
         principleBalances[clientChainLzId][assetsAddress][withdrawer] -= opAmount;
+        return (true, principleBalances[clientChainLzId][assetsAddress][withdrawer]);
     }
 
 }

--- a/test/mocks/ExocoreGatewayMock.sol
+++ b/test/mocks/ExocoreGatewayMock.sol
@@ -39,7 +39,7 @@ contract ExocoreGatewayMock is
         REQUEST_DEPOSIT_THEN_DELEGATE_TO,
         REQUEST_MARK_BOOTSTRAP,
         RESPOND,
-        UPDATE_USERS_BALANCES,
+        UPDATE_USERS_BALANCES
     }
 
     mapping(Action => bytes4) public whiteListFunctionSelectors;

--- a/test/mocks/ExocoreGatewayMock.sol
+++ b/test/mocks/ExocoreGatewayMock.sol
@@ -36,9 +36,10 @@ contract ExocoreGatewayMock is
         REQUEST_WITHDRAW_REWARD_FROM_EXOCORE,
         REQUEST_DELEGATE_TO,
         REQUEST_UNDELEGATE_FROM,
+        REQUEST_DEPOSIT_THEN_DELEGATE_TO,
+        REQUEST_MARK_BOOTSTRAP,
         RESPOND,
         UPDATE_USERS_BALANCES,
-        MARK_BOOTSTRAP
     }
 
     mapping(Action => bytes4) public whiteListFunctionSelectors;
@@ -134,7 +135,7 @@ contract ExocoreGatewayMock is
         for (uint256 i = 0; i < clientChainIds.length; i++) {
             uint16 clientChainId = clientChainIds[i];
             if (!chainToBootstrapped[clientChainId]) {
-                _sendInterchainMsg(uint32(clientChainId), Action.MARK_BOOTSTRAP, "");
+                _sendInterchainMsg(uint32(clientChainId), Action.REQUEST_MARK_BOOTSTRAP, "");
                 // TODO: should this be marked only when receiving a response?
                 chainToBootstrapped[clientChainId] = true;
             }


### PR DESCRIPTION
Fixes: #4 

- Add a new function in `ILSTRestakingController` called `depositThenDelegateTo`.
- Implement said function in `Bootstrap`
- Implement said function in `LSTRestakingController`, which is inherited by `ClientChainGateway`
- Process the LZ request generated from said function in `ExocoreGateway`
- Handle the response from the processing in `ClientChainGateway`
- Add a unit test (one each for the bootstrap and the gateway) for the call, making the `generateUID` function common in tests inheriting from `ExocoreDeployer`. With unit tests, we verify that (1) deposit is received, (2) delegate is received, and (3) the assets are withdrawn from the user's balance and increased in the vault.

Based on previous discussions, it is assumed that the deposit part does not fail and any failure returned by `ExocoreGateway` to `ClientChainGateway` refers to the delegation. This is correctly reflected in the event definition as provided below. Note that the `delegatedAmount` will be, by definition, equal to the amount that is being deposited since both the steps happen atomically. 

```solidity
    event DepositThenDelegateResult(
        bool indexed delegateSuccess,
        address indexed delegator,
        string indexed delegatee,
        address token,
        uint256 delegatedAmount
    );
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced the ability to deposit tokens and delegate them to another address in a single transaction.
  
- **Enhancements**
  - Improved the flow for token deposit and delegation to streamline user interactions.

- **Bug Fixes**
  - Enhanced security checks during withdrawals to ensure ether balance requirements are met.

- **Tests**
  - Added comprehensive tests for the new deposit-then-delegate functionality, ensuring robustness and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->