### PR TITLE
fix(lzApp): NotEnoughNative -> NotExactNativeFee

### DIFF
--- a/src/lzApp/OAppSenderUpgradeable.sol
+++ b/src/lzApp/OAppSenderUpgradeable.sol
@@ -19,7 +19,7 @@ abstract contract OAppSenderUpgradeable is OAppCoreUpgradeable {
     using SafeERC20 for IERC20;
 
     // Custom error messages
-    error NotExactNative(uint256 msgValue);
+    error NotExactNativeFee(uint256 msgValue);
     error LzTokenUnavailable();
 
     // @dev The version of the OAppSender implementation.
@@ -114,7 +114,7 @@ abstract contract OAppSenderUpgradeable is OAppCoreUpgradeable {
      */
     function _payNative(uint256 _nativeFee, bool byApp) internal virtual returns (uint256 nativeFee) {
         if (!byApp && msg.value != _nativeFee) {
-            revert NotExactNative(msg.value);
+            revert NotExactNativeFee(msg.value);
         }
         return _nativeFee;
     }

--- a/src/lzApp/OAppSenderUpgradeable.sol
+++ b/src/lzApp/OAppSenderUpgradeable.sol
@@ -19,7 +19,7 @@ abstract contract OAppSenderUpgradeable is OAppCoreUpgradeable {
     using SafeERC20 for IERC20;
 
     // Custom error messages
-    error NotEnoughNative(uint256 msgValue);
+    error NotExactNative(uint256 msgValue);
     error LzTokenUnavailable();
 
     // @dev The version of the OAppSender implementation.
@@ -114,7 +114,7 @@ abstract contract OAppSenderUpgradeable is OAppCoreUpgradeable {
      */
     function _payNative(uint256 _nativeFee, bool byApp) internal virtual returns (uint256 nativeFee) {
         if (!byApp && msg.value != _nativeFee) {
-            revert NotEnoughNative(msg.value);
+            revert NotExactNative(msg.value);
         }
         return _nativeFee;
     }


### PR DESCRIPTION
The former makes it sound like not enough fee was supplied, but it is also thrown when excess fee is supplied.

Fixes: #9 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated error message from `NotEnoughNative` to `NotExactNativeFee` for more precise error handling related to native fees.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->