### PR TITLE
security-enhance: add ReentrancyGuard to contracts

### DIFF
--- a/src/core/BaseRestakingController.sol
+++ b/src/core/BaseRestakingController.sol
@@ -8,9 +8,11 @@ import {ClientChainGatewayStorage} from "../storage/ClientChainGatewayStorage.so
 
 import {OptionsBuilder} from "@layerzero-v2/oapp/contracts/oapp/libs/OptionsBuilder.sol";
 import {PausableUpgradeable} from "@openzeppelin-upgradeable/contracts/utils/PausableUpgradeable.sol";
+import {ReentrancyGuardUpgradeable} from "@openzeppelin-upgradeable/contracts/utils/ReentrancyGuardUpgradeable.sol";
 
 abstract contract BaseRestakingController is
     PausableUpgradeable,
+    ReentrancyGuardUpgradeable,
     OAppSenderUpgradeable,
     IBaseRestakingController,
     ClientChainGatewayStorage
@@ -25,6 +27,7 @@ abstract contract BaseRestakingController is
         isTokenWhitelisted(token)
         isValidAmount(amount)
         whenNotPaused
+        nonReentrant
     {
         if (token == VIRTUAL_STAKED_ETH_ADDRESS) {
             IExoCapsule capsule = _getCapsule(msg.sender);
@@ -44,6 +47,7 @@ abstract contract BaseRestakingController is
         isValidAmount(amount)
         isValidBech32Address(operator)
         whenNotPaused
+        nonReentrant
     {
         bytes memory actionArgs =
             abi.encodePacked(bytes32(bytes20(token)), bytes32(bytes20(msg.sender)), bytes(operator), amount);
@@ -58,6 +62,7 @@ abstract contract BaseRestakingController is
         isValidAmount(amount)
         isValidBech32Address(operator)
         whenNotPaused
+        nonReentrant
     {
         bytes memory actionArgs =
             abi.encodePacked(bytes32(bytes20(token)), bytes32(bytes20(msg.sender)), bytes(operator), amount);

--- a/src/core/Bootstrap.sol
+++ b/src/core/Bootstrap.sol
@@ -81,6 +81,7 @@ contract Bootstrap is
         // contract controlled by one.
         __Ownable_init_unchained(owner);
         __Pausable_init_unchained();
+        __ReentrancyGuard_init_unchained();
     }
 
     /**

--- a/src/core/ClientChainGateway.sol
+++ b/src/core/ClientChainGateway.sol
@@ -84,6 +84,7 @@ contract ClientChainGateway is
         __Ownable_init_unchained(exocoreValidatorSetAddress);
         __OAppCore_init_unchained(exocoreValidatorSetAddress);
         __Pausable_init_unchained();
+        __ReentrancyGuard_init_unchained();
     }
 
     function _clearBootstrapData() internal {
@@ -119,7 +120,7 @@ contract ClientChainGateway is
     }
 
     // implementation of ITokenWhitelister
-    function addWhitelistTokens(address[] calldata tokens) external payable onlyOwner whenNotPaused {
+    function addWhitelistTokens(address[] calldata tokens) external payable onlyOwner whenNotPaused nonReentrant {
         _addWhitelistTokens(tokens);
     }
 

--- a/src/core/ExocoreGateway.sol
+++ b/src/core/ExocoreGateway.sol
@@ -148,7 +148,13 @@ contract ExocoreGateway is
         }
     }
 
-    function _lzReceive(Origin calldata _origin, bytes calldata payload) internal virtual override whenNotPaused nonReentrant {
+    function _lzReceive(Origin calldata _origin, bytes calldata payload)
+        internal
+        virtual
+        override
+        whenNotPaused
+        nonReentrant
+    {
         _verifyAndUpdateNonce(_origin.srcEid, _origin.sender, _origin.nonce);
 
         Action act = Action(uint8(payload[0]));

--- a/src/core/LSTRestakingController.sol
+++ b/src/core/LSTRestakingController.sol
@@ -6,8 +6,14 @@ import {IVault} from "../interfaces/IVault.sol";
 import {BaseRestakingController} from "./BaseRestakingController.sol";
 
 import {PausableUpgradeable} from "@openzeppelin-upgradeable/contracts/utils/PausableUpgradeable.sol";
+import {ReentrancyGuardUpgradeable} from "@openzeppelin-upgradeable/contracts/utils/ReentrancyGuardUpgradeable.sol";
 
-abstract contract LSTRestakingController is PausableUpgradeable, ILSTRestakingController, BaseRestakingController {
+abstract contract LSTRestakingController is
+    PausableUpgradeable,
+    ReentrancyGuardUpgradeable,
+    ILSTRestakingController,
+    BaseRestakingController
+{
 
     function deposit(address token, uint256 amount)
         external
@@ -15,6 +21,7 @@ abstract contract LSTRestakingController is PausableUpgradeable, ILSTRestakingCo
         isTokenWhitelisted(token)
         isValidAmount(amount)
         whenNotPaused
+        nonReentrant
     {
         IVault vault = _getVault(token);
         vault.deposit(msg.sender, amount);
@@ -31,6 +38,7 @@ abstract contract LSTRestakingController is PausableUpgradeable, ILSTRestakingCo
         isTokenWhitelisted(token)
         isValidAmount(principalAmount)
         whenNotPaused
+        nonReentrant
     {
         bytes memory actionArgs =
             abi.encodePacked(bytes32(bytes20(token)), bytes32(bytes20(msg.sender)), principalAmount);
@@ -45,6 +53,7 @@ abstract contract LSTRestakingController is PausableUpgradeable, ILSTRestakingCo
         isTokenWhitelisted(token)
         isValidAmount(rewardAmount)
         whenNotPaused
+        nonReentrant
     {
         bytes memory actionArgs = abi.encodePacked(bytes32(bytes20(token)), bytes32(bytes20(msg.sender)), rewardAmount);
         bytes memory encodedRequest = abi.encode(token, msg.sender, rewardAmount);
@@ -60,6 +69,7 @@ abstract contract LSTRestakingController is PausableUpgradeable, ILSTRestakingCo
         isValidAmount(amount)
         isValidBech32Address(operator)
         whenNotPaused
+        nonReentrant
     {
         IVault vault = _getVault(token);
         vault.deposit(msg.sender, amount);

--- a/src/core/NativeRestakingController.sol
+++ b/src/core/NativeRestakingController.sol
@@ -8,10 +8,12 @@ import {BaseRestakingController} from "./BaseRestakingController.sol";
 import {ExoCapsule} from "./ExoCapsule.sol";
 
 import {PausableUpgradeable} from "@openzeppelin-upgradeable/contracts/utils/PausableUpgradeable.sol";
+import {ReentrancyGuardUpgradeable} from "@openzeppelin-upgradeable/contracts/utils/ReentrancyGuardUpgradeable.sol";
 import {Create2} from "@openzeppelin/contracts/utils/Create2.sol";
 
 abstract contract NativeRestakingController is
     PausableUpgradeable,
+    ReentrancyGuardUpgradeable,
     INativeRestakingController,
     BaseRestakingController
 {
@@ -22,6 +24,7 @@ abstract contract NativeRestakingController is
         external
         payable
         whenNotPaused
+        nonReentrant
     {
         require(msg.value == 32 ether, "NativeRestakingController: stake value must be exactly 32 ether");
 
@@ -58,7 +61,7 @@ abstract contract NativeRestakingController is
     function depositBeaconChainValidator(
         bytes32[] calldata validatorContainer,
         IExoCapsule.ValidatorContainerProof calldata proof
-    ) external payable whenNotPaused {
+    ) external payable whenNotPaused nonReentrant {
         IExoCapsule capsule = _getCapsule(msg.sender);
         capsule.verifyDepositProof(validatorContainer, proof);
 
@@ -75,13 +78,13 @@ abstract contract NativeRestakingController is
         IExoCapsule.ValidatorContainerProof calldata validatorProof,
         bytes32[] calldata withdrawalContainer,
         IExoCapsule.WithdrawalContainerProof calldata withdrawalProof
-    ) external payable whenNotPaused {}
+    ) external payable whenNotPaused nonReentrant {}
 
     function processBeaconChainFullWithdrawal(
         bytes32[] calldata validatorContainer,
         IExoCapsule.ValidatorContainerProof calldata validatorProof,
         bytes32[] calldata withdrawalContainer,
         IExoCapsule.WithdrawalContainerProof calldata withdrawalProof
-    ) external payable whenNotPaused {}
+    ) external payable whenNotPaused nonReentrant {}
 
 }


### PR DESCRIPTION
## Description

closes: #28 

slither complains about some reentrancy issues though most of external calls our contracts make are calling whitelisted token contracts. It's better that we add `ReentrancyGuard` to existing contracts, especially contracts that provide user facing functions and add `nonReentrant` modifier to those functions that would make external calls(to some ERC20 token, or even to layerzero endpoint).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced security with the addition of reentrancy protection across multiple contracts.
  
- **Improvements**
  - Introduced `nonReentrant` modifier to critical functions, preventing reentrancy attacks.

- **Security Enhancements**
  - Applied `ReentrancyGuardUpgradeable` to various controllers to ensure safer operations when staking, unstaking, and claiming rewards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->