### PR TITLE
chore: use latest version of foundry tools

### DIFF
--- a/.github/workflows/forge-ci.yml
+++ b/.github/workflows/forge-ci.yml
@@ -14,7 +14,7 @@ jobs:
   setup:
     uses: ./.github/workflows/foundry-setup.yml
     with:
-      foundry-version: nightly-f625d0fa7c51e65b4bf1e8f7931cd1c6e2e285e9
+      foundry-version: nightly
 
   build:
     runs-on: ubuntu-latest

--- a/test/foundry/ExocoreDeployer.t.sol
+++ b/test/foundry/ExocoreDeployer.t.sol
@@ -26,6 +26,10 @@ import {IVault} from "../../src/interfaces/IVault.sol";
 import "../../src/interfaces/precompiles/IAssets.sol";
 import "../../src/interfaces/precompiles/IClaimReward.sol";
 import "../../src/interfaces/precompiles/IDelegation.sol";
+
+import "../mocks/AssetsMock.sol";
+import "../mocks/ClaimRewardMock.sol";
+import "../mocks/DelegationMock.sol";
 import {NonShortCircuitEndpointV2Mock} from "../mocks/NonShortCircuitEndpointV2Mock.sol";
 
 import "src/core/BeaconProxyBytecode.sol";


### PR DESCRIPTION
## Description

the latest version of foundry tools have brought useful features like https://github.com/foundry-rs/foundry/pull/7334#issuecomment-1987154623, which requires importing source files if we want to get its code by calling `getDeployedCode`. This PR updates foundry version used in CI to `nightly` instead of specific version and fix failed tests.

- [x] foundry version `nightly-f625d0fa7c51e65b4bf1e8f7931cd1c6e2e285e9` => `nightly` in `forge-ci.yml`
- [x] import source file for `getDeployedCode`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated `foundry-version` parameter in CI configuration for improved stability.

- **Tests**
	- Added mock implementations to test suite for enhanced coverage and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->