### PR TITLE
chore: downgrade openzeppelin-contracts-upgradeable from v5 to v4

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,9 +7,6 @@
 [submodule "lib/openzeppelin-contracts"]
 	path = lib/openzeppelin-contracts
 	url = https://github.com/OpenZeppelin/openzeppelin-contracts
-[submodule "lib/openzeppelin-contracts-upgradeable"]
-	path = lib/openzeppelin-contracts-upgradeable
-	url = https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable
 [submodule "lib/LayerZero"]
 	path = lib/LayerZero
 	url = https://github.com/LayerZero-Labs/LayerZero
@@ -22,3 +19,6 @@
 [submodule "lib/eigenlayer-beacon-oracle"]
 	path = lib/eigenlayer-beacon-oracle
 	url = https://github.com/succinctlabs/eigenlayer-beacon-oracle
+[submodule "lib/openzeppelin-contracts-upgradeable"]
+	path = lib/openzeppelin-contracts-upgradeable
+	url = https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,8 +1,8 @@
 ds-test/=lib/forge-std/lib/ds-test/src/
 forge-std/=lib/forge-std/src/
 @layerzero-contracts/=lib/solidity-examples/contracts/
-@openzeppelin-upgradeable/=lib/openzeppelin-contracts-upgradeable/
-@openzeppelin-contracts/=lib/openzeppelin-contracts/
+@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/
+@openzeppelin/contracts-upgradeable/=lib/openzeppelin-contracts-upgradeable/contracts/
 @layerzero-v2/=lib/LayerZero-v2/
 @layerzerolabs/lz-evm-protocol-v2=lib/LayerZero-v2/protocol/
 @layerzerolabs/lz-evm-oapp-v2=lib/LayerZero-v2/oapp/

--- a/script/10_DeployExocoreGatewayOnly.s.sol
+++ b/script/10_DeployExocoreGatewayOnly.s.sol
@@ -2,9 +2,8 @@ pragma solidity ^0.8.19;
 
 import {ILayerZeroEndpointV2} from "@layerzero-v2/protocol/contracts/interfaces/ILayerZeroEndpointV2.sol";
 
-import {ProxyAdmin} from "@openzeppelin-contracts/contracts/proxy/transparent/ProxyAdmin.sol";
-import {TransparentUpgradeableProxy} from
-    "@openzeppelin-contracts/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+import {TransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 
 import {ExocoreGateway} from "../src/core/ExocoreGateway.sol";
 

--- a/script/12_RedeployClientChainGateway.s.sol
+++ b/script/12_RedeployClientChainGateway.s.sol
@@ -1,8 +1,7 @@
 pragma solidity ^0.8.19;
 
-import {UpgradeableBeacon} from "@openzeppelin-contracts/contracts/proxy/beacon/UpgradeableBeacon.sol";
-import {TransparentUpgradeableProxy} from
-    "@openzeppelin-contracts/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {UpgradeableBeacon} from "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";
+import {TransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 
 import "../src/core/BeaconProxyBytecode.sol";
 import {Bootstrap} from "../src/core/Bootstrap.sol";
@@ -15,7 +14,7 @@ import {BaseScript} from "./BaseScript.sol";
 
 import "@beacon-oracle/contracts/src/EigenLayerBeaconOracle.sol";
 import {ILayerZeroEndpointV2} from "@layerzero-v2/protocol/contracts/interfaces/ILayerZeroEndpointV2.sol";
-import {ERC20PresetFixedSupply} from "@openzeppelin-contracts/contracts/token/ERC20/presets/ERC20PresetFixedSupply.sol";
+import {ERC20PresetFixedSupply} from "@openzeppelin/contracts/token/ERC20/presets/ERC20PresetFixedSupply.sol";
 import "forge-std/Script.sol";
 
 contract RedeployClientChainGateway is BaseScript {

--- a/script/13_DepositValidator.s.sol
+++ b/script/13_DepositValidator.s.sol
@@ -10,7 +10,7 @@ import "@beacon-oracle/contracts/src/EigenLayerBeaconOracle.sol";
 import "@layerzero-v2/protocol/contracts/interfaces/ILayerZeroEndpointV2.sol";
 import "@layerzero-v2/protocol/contracts/libs/AddressCast.sol";
 import "@layerzerolabs/lz-evm-protocol-v2/contracts/libs/GUID.sol";
-import {ERC20PresetFixedSupply} from "@openzeppelin-contracts/contracts/token/ERC20/presets/ERC20PresetFixedSupply.sol";
+import {ERC20PresetFixedSupply} from "@openzeppelin/contracts/token/ERC20/presets/ERC20PresetFixedSupply.sol";
 import "forge-std/Script.sol";
 
 import "src/libraries/Endian.sol";

--- a/script/1_Prerequisities.s.sol
+++ b/script/1_Prerequisities.s.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.19;
 import "./BaseScript.sol";
 import "@beacon-oracle/contracts/src/EigenLayerBeaconOracle.sol";
 import "@layerzero-v2/protocol/contracts/interfaces/ILayerZeroEndpointV2.sol";
-import {ERC20PresetFixedSupply} from "@openzeppelin-contracts/contracts/token/ERC20/presets/ERC20PresetFixedSupply.sol";
+import {ERC20PresetFixedSupply} from "@openzeppelin/contracts/token/ERC20/presets/ERC20PresetFixedSupply.sol";
 import "forge-std/Script.sol";
 
 import "test/mocks/AssetsMock.sol";

--- a/script/2_DeployBoth.s.sol
+++ b/script/2_DeployBoth.s.sol
@@ -10,10 +10,10 @@ import {ExocoreGatewayMock} from "../test/mocks/ExocoreGatewayMock.sol";
 import {BaseScript} from "./BaseScript.sol";
 import "@beacon-oracle/contracts/src/EigenLayerBeaconOracle.sol";
 import "@layerzero-v2/protocol/contracts/interfaces/ILayerZeroEndpointV2.sol";
-import {UpgradeableBeacon} from "@openzeppelin-contracts/contracts/proxy/beacon/UpgradeableBeacon.sol";
-import "@openzeppelin-contracts/contracts/proxy/transparent/ProxyAdmin.sol";
-import "@openzeppelin-contracts/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
-import {ERC20PresetFixedSupply} from "@openzeppelin-contracts/contracts/token/ERC20/presets/ERC20PresetFixedSupply.sol";
+import {UpgradeableBeacon} from "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";
+import "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+import "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {ERC20PresetFixedSupply} from "@openzeppelin/contracts/token/ERC20/presets/ERC20PresetFixedSupply.sol";
 import "forge-std/Script.sol";
 
 contract DeployScript is BaseScript {

--- a/script/3_Setup.s.sol
+++ b/script/3_Setup.s.sol
@@ -9,7 +9,7 @@ import {NonShortCircuitEndpointV2Mock} from "../test/mocks/NonShortCircuitEndpoi
 import {BaseScript} from "./BaseScript.sol";
 import "@layerzero-v2/protocol/contracts/interfaces/ILayerZeroEndpointV2.sol";
 import "@layerzero-v2/protocol/contracts/libs/AddressCast.sol";
-import {ERC20PresetFixedSupply} from "@openzeppelin-contracts/contracts/token/ERC20/presets/ERC20PresetFixedSupply.sol";
+import {ERC20PresetFixedSupply} from "@openzeppelin/contracts/token/ERC20/presets/ERC20PresetFixedSupply.sol";
 import "forge-std/Script.sol";
 
 contract SetupScript is BaseScript {

--- a/script/4_Deposit.s.sol
+++ b/script/4_Deposit.s.sol
@@ -10,7 +10,7 @@ import {BaseScript} from "./BaseScript.sol";
 import "@layerzero-v2/protocol/contracts/interfaces/ILayerZeroEndpointV2.sol";
 import "@layerzero-v2/protocol/contracts/libs/AddressCast.sol";
 import "@layerzerolabs/lz-evm-protocol-v2/contracts/libs/GUID.sol";
-import {ERC20PresetFixedSupply} from "@openzeppelin-contracts/contracts/token/ERC20/presets/ERC20PresetFixedSupply.sol";
+import {ERC20PresetFixedSupply} from "@openzeppelin/contracts/token/ERC20/presets/ERC20PresetFixedSupply.sol";
 import "forge-std/Script.sol";
 
 contract DepositScript is BaseScript {

--- a/script/5_Withdraw.s.sol
+++ b/script/5_Withdraw.s.sol
@@ -11,7 +11,7 @@ import {BaseScript} from "./BaseScript.sol";
 import "@layerzero-v2/protocol/contracts/interfaces/ILayerZeroEndpointV2.sol";
 import "@layerzero-v2/protocol/contracts/libs/AddressCast.sol";
 import "@layerzerolabs/lz-evm-protocol-v2/contracts/libs/GUID.sol";
-import {ERC20PresetFixedSupply} from "@openzeppelin-contracts/contracts/token/ERC20/presets/ERC20PresetFixedSupply.sol";
+import {ERC20PresetFixedSupply} from "@openzeppelin/contracts/token/ERC20/presets/ERC20PresetFixedSupply.sol";
 import "forge-std/Script.sol";
 
 contract DepositScript is BaseScript {

--- a/script/6_CreateExoCapsule.s.sol
+++ b/script/6_CreateExoCapsule.s.sol
@@ -11,7 +11,7 @@ import {BaseScript} from "./BaseScript.sol";
 import "@layerzero-v2/protocol/contracts/interfaces/ILayerZeroEndpointV2.sol";
 import "@layerzero-v2/protocol/contracts/libs/AddressCast.sol";
 import "@layerzerolabs/lz-evm-protocol-v2/contracts/libs/GUID.sol";
-import {ERC20PresetFixedSupply} from "@openzeppelin-contracts/contracts/token/ERC20/presets/ERC20PresetFixedSupply.sol";
+import {ERC20PresetFixedSupply} from "@openzeppelin/contracts/token/ERC20/presets/ERC20PresetFixedSupply.sol";
 import "forge-std/Script.sol";
 
 import "forge-std/StdJson.sol";

--- a/script/7_DeployBootstrap.s.sol
+++ b/script/7_DeployBootstrap.s.sol
@@ -1,8 +1,7 @@
 pragma solidity ^0.8.19;
 
-import {UpgradeableBeacon} from "@openzeppelin-contracts/contracts/proxy/beacon/UpgradeableBeacon.sol";
-import {TransparentUpgradeableProxy} from
-    "@openzeppelin-contracts/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {UpgradeableBeacon} from "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";
+import {TransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 
 import "../src/core/BeaconProxyBytecode.sol";
 import {Bootstrap} from "../src/core/Bootstrap.sol";
@@ -13,7 +12,7 @@ import {Vault} from "../src/core/Vault.sol";
 
 import {BaseScript} from "./BaseScript.sol";
 import {ILayerZeroEndpointV2} from "@layerzero-v2/protocol/contracts/interfaces/ILayerZeroEndpointV2.sol";
-import {ERC20PresetFixedSupply} from "@openzeppelin-contracts/contracts/token/ERC20/presets/ERC20PresetFixedSupply.sol";
+import {ERC20PresetFixedSupply} from "@openzeppelin/contracts/token/ERC20/presets/ERC20PresetFixedSupply.sol";
 import "forge-std/Script.sol";
 
 import "@beacon-oracle/contracts/src/EigenLayerBeaconOracle.sol";

--- a/script/8_RegisterOperatorsAndDelegate.s.sol
+++ b/script/8_RegisterOperatorsAndDelegate.s.sol
@@ -4,7 +4,7 @@ import {Bootstrap} from "../src/core/Bootstrap.sol";
 import {Vault} from "../src/core/Vault.sol";
 import {IOperatorRegistry} from "../src/interfaces/IOperatorRegistry.sol";
 
-import {ERC20PresetFixedSupply} from "@openzeppelin-contracts/contracts/token/ERC20/presets/ERC20PresetFixedSupply.sol";
+import {ERC20PresetFixedSupply} from "@openzeppelin/contracts/token/ERC20/presets/ERC20PresetFixedSupply.sol";
 
 import "forge-std/Script.sol";
 

--- a/script/BaseScript.sol
+++ b/script/BaseScript.sol
@@ -12,11 +12,8 @@ import "../src/interfaces/precompiles/IDelegation.sol";
 
 import "@beacon-oracle/contracts/src/EigenLayerBeaconOracle.sol";
 import "@layerzero-v2/protocol/contracts/interfaces/ILayerZeroEndpointV2.sol";
-import {IBeacon} from "@openzeppelin-contracts/contracts/proxy/beacon/IBeacon.sol";
-import {
-    ERC20PresetFixedSupply,
-    IERC20
-} from "@openzeppelin-contracts/contracts/token/ERC20/presets/ERC20PresetFixedSupply.sol";
+import {IBeacon} from "@openzeppelin/contracts/proxy/beacon/IBeacon.sol";
+import {ERC20PresetFixedSupply, IERC20} from "@openzeppelin/contracts/token/ERC20/presets/ERC20PresetFixedSupply.sol";
 import "forge-std/Script.sol";
 
 contract BaseScript is Script {

--- a/script/TestPrecompileErrorFixed.s.sol
+++ b/script/TestPrecompileErrorFixed.s.sol
@@ -15,8 +15,8 @@ import {BaseScript} from "./BaseScript.sol";
 import "@layerzero-v2/protocol/contracts/interfaces/ILayerZeroEndpointV2.sol";
 import "@layerzero-v2/protocol/contracts/libs/AddressCast.sol";
 import "@layerzerolabs/lz-evm-protocol-v2/contracts/libs/GUID.sol";
-import "@openzeppelin-contracts/contracts/proxy/transparent/ProxyAdmin.sol";
-import {ERC20PresetFixedSupply} from "@openzeppelin-contracts/contracts/token/ERC20/presets/ERC20PresetFixedSupply.sol";
+import "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+import {ERC20PresetFixedSupply} from "@openzeppelin/contracts/token/ERC20/presets/ERC20PresetFixedSupply.sol";
 import "forge-std/Script.sol";
 
 import "src/core/ClientChainGateway.sol";

--- a/script/TestPrecompileErrorFixed_Deploy.s.sol
+++ b/script/TestPrecompileErrorFixed_Deploy.s.sol
@@ -12,8 +12,8 @@ import {BaseScript} from "./BaseScript.sol";
 import "@layerzero-v2/protocol/contracts/interfaces/ILayerZeroEndpointV2.sol";
 import "@layerzero-v2/protocol/contracts/libs/AddressCast.sol";
 import "@layerzerolabs/lz-evm-protocol-v2/contracts/libs/GUID.sol";
-import "@openzeppelin-contracts/contracts/proxy/transparent/ProxyAdmin.sol";
-import {ERC20PresetFixedSupply} from "@openzeppelin-contracts/contracts/token/ERC20/presets/ERC20PresetFixedSupply.sol";
+import "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+import {ERC20PresetFixedSupply} from "@openzeppelin/contracts/token/ERC20/presets/ERC20PresetFixedSupply.sol";
 import "forge-std/Script.sol";
 
 import "src/core/ClientChainGateway.sol";

--- a/script/TokenTransfer.s.sol
+++ b/script/TokenTransfer.s.sol
@@ -7,11 +7,11 @@ import {Vault} from "../src/core/Vault.sol";
 
 import "../src/storage/GatewayStorage.sol";
 import "@layerzero-contracts/interfaces/ILayerZeroEndpoint.sol";
-import "@openzeppelin-contracts/contracts/proxy/transparent/ProxyAdmin.sol";
-import "@openzeppelin-contracts/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
-import "@openzeppelin-contracts/contracts/token/ERC20/presets/ERC20PresetFixedSupply.sol";
+import "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+import "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import "@openzeppelin/contracts/token/ERC20/presets/ERC20PresetFixedSupply.sol";
 
-import "@openzeppelin-contracts/contracts/token/ERC20/presets/ERC20PresetFixedSupply.sol";
+import "@openzeppelin/contracts/token/ERC20/presets/ERC20PresetFixedSupply.sol";
 import "forge-std/Script.sol";
 
 contract DeployScript is Script {

--- a/script/deployBeaconOracle.s.sol
+++ b/script/deployBeaconOracle.s.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.19;
 import "./BaseScript.sol";
 import "@beacon-oracle/contracts/src/EigenLayerBeaconOracle.sol";
 import "@layerzero-v2/protocol/contracts/interfaces/ILayerZeroEndpointV2.sol";
-import {ERC20PresetFixedSupply} from "@openzeppelin-contracts/contracts/token/ERC20/presets/ERC20PresetFixedSupply.sol";
+import {ERC20PresetFixedSupply} from "@openzeppelin/contracts/token/ERC20/presets/ERC20PresetFixedSupply.sol";
 import "forge-std/Script.sol";
 
 import {NonShortCircuitEndpointV2Mock} from "test/mocks/NonShortCircuitEndpointV2Mock.sol";

--- a/script/integration/1_DeployBootstrap.s.sol
+++ b/script/integration/1_DeployBootstrap.s.sol
@@ -4,9 +4,9 @@ pragma solidity ^0.8.0;
 import "forge-std/Script.sol";
 import "forge-std/console.sol";
 
-import {IBeacon} from "@openzeppelin-contracts/contracts/proxy/beacon/IBeacon.sol";
-import {UpgradeableBeacon} from "@openzeppelin-contracts/contracts/proxy/beacon/UpgradeableBeacon.sol";
-import "@openzeppelin-contracts/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {IBeacon} from "@openzeppelin/contracts/proxy/beacon/IBeacon.sol";
+import {UpgradeableBeacon} from "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";
+import "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 
 import {EndpointV2Mock} from "../../test/mocks/EndpointV2Mock.sol";
 

--- a/src/core/BaseRestakingController.sol
+++ b/src/core/BaseRestakingController.sol
@@ -7,8 +7,8 @@ import {MessagingFee, MessagingReceipt, OAppSenderUpgradeable} from "../lzApp/OA
 import {ClientChainGatewayStorage} from "../storage/ClientChainGatewayStorage.sol";
 
 import {OptionsBuilder} from "@layerzero-v2/oapp/contracts/oapp/libs/OptionsBuilder.sol";
-import {PausableUpgradeable} from "@openzeppelin-upgradeable/contracts/utils/PausableUpgradeable.sol";
-import {ReentrancyGuardUpgradeable} from "@openzeppelin-upgradeable/contracts/utils/ReentrancyGuardUpgradeable.sol";
+import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
+import {ReentrancyGuardUpgradeable} from "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
 
 abstract contract BaseRestakingController is
     PausableUpgradeable,

--- a/src/core/Bootstrap.sol
+++ b/src/core/Bootstrap.sol
@@ -2,12 +2,11 @@ pragma solidity ^0.8.19;
 
 // Do not use IERC20 because it does not expose the decimals() function.
 
-import {ITransparentUpgradeableProxy} from
-    "@openzeppelin-contracts/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
-import {OwnableUpgradeable} from "@openzeppelin-upgradeable/contracts/access/OwnableUpgradeable.sol";
-import {Initializable} from "@openzeppelin-upgradeable/contracts/proxy/utils/Initializable.sol";
-import {PausableUpgradeable} from "@openzeppelin-upgradeable/contracts/utils/PausableUpgradeable.sol";
-import {ReentrancyGuardUpgradeable} from "@openzeppelin-upgradeable/contracts/utils/ReentrancyGuardUpgradeable.sol";
+import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
+import {ReentrancyGuardUpgradeable} from "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
+import {ITransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 import {OAppCoreUpgradeable} from "../lzApp/OAppCoreUpgradeable.sol";
@@ -79,7 +78,7 @@ contract Bootstrap is
         // cannot be used here. we must require a separate owner. since the Exocore validator
         // set can not sign without the chain, the owner is likely to be an EOA or a
         // contract controlled by one.
-        __Ownable_init_unchained(owner);
+        _transferOwnership(owner);
         __Pausable_init_unchained();
         __ReentrancyGuard_init_unchained();
     }

--- a/src/core/BootstrapLzReceiver.sol
+++ b/src/core/BootstrapLzReceiver.sol
@@ -2,7 +2,7 @@ pragma solidity ^0.8.19;
 
 import {OAppReceiverUpgradeable, Origin} from "../lzApp/OAppReceiverUpgradeable.sol";
 import {BootstrapStorage} from "../storage/BootstrapStorage.sol";
-import {PausableUpgradeable} from "@openzeppelin-upgradeable/contracts/utils/PausableUpgradeable.sol";
+import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
 
 abstract contract BootstrapLzReceiver is PausableUpgradeable, OAppReceiverUpgradeable, BootstrapStorage {
 

--- a/src/core/ClientChainGateway.sol
+++ b/src/core/ClientChainGateway.sol
@@ -12,9 +12,9 @@ import {NativeRestakingController} from "./NativeRestakingController.sol";
 
 import {IOAppCore} from "@layerzero-v2/oapp/contracts/oapp/interfaces/IOAppCore.sol";
 import {OptionsBuilder} from "@layerzero-v2/oapp/contracts/oapp/libs/OptionsBuilder.sol";
-import {OwnableUpgradeable} from "@openzeppelin-upgradeable/contracts/access/OwnableUpgradeable.sol";
-import {Initializable} from "@openzeppelin-upgradeable/contracts/proxy/utils/Initializable.sol";
-import {PausableUpgradeable} from "@openzeppelin-upgradeable/contracts/utils/PausableUpgradeable.sol";
+import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
 
 contract ClientChainGateway is
     Initializable,
@@ -83,7 +83,7 @@ contract ClientChainGateway is
 
         bootstrapped = true;
 
-        __Ownable_init_unchained(exocoreValidatorSetAddress);
+        _transferOwnership(exocoreValidatorSetAddress);
         __OAppCore_init_unchained(exocoreValidatorSetAddress);
         __Pausable_init_unchained();
         __ReentrancyGuard_init_unchained();

--- a/src/core/ClientGatewayLzReceiver.sol
+++ b/src/core/ClientGatewayLzReceiver.sol
@@ -5,7 +5,7 @@ import {IVault} from "../interfaces/IVault.sol";
 import {OAppReceiverUpgradeable, Origin} from "../lzApp/OAppReceiverUpgradeable.sol";
 import {ClientChainGatewayStorage} from "../storage/ClientChainGatewayStorage.sol";
 
-import {PausableUpgradeable} from "@openzeppelin-upgradeable/contracts/utils/PausableUpgradeable.sol";
+import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
 
 abstract contract ClientGatewayLzReceiver is PausableUpgradeable, OAppReceiverUpgradeable, ClientChainGatewayStorage {
 

--- a/src/core/CustomProxyAdmin.sol
+++ b/src/core/CustomProxyAdmin.sol
@@ -1,9 +1,8 @@
 pragma solidity ^0.8.19;
 
-import {ProxyAdmin} from "@openzeppelin-contracts/contracts/proxy/transparent/ProxyAdmin.sol";
-import {ITransparentUpgradeableProxy} from
-    "@openzeppelin-contracts/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
-import {Initializable} from "@openzeppelin-upgradeable/contracts/proxy/utils/Initializable.sol";
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+import {ITransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 
 // This contract is not upgradeable intentionally, since doing so would produce a lot of risk.
 contract CustomProxyAdmin is Initializable, ProxyAdmin {

--- a/src/core/ExoCapsule.sol
+++ b/src/core/ExoCapsule.sol
@@ -9,7 +9,7 @@ import {WithdrawalContainer} from "../libraries/WithdrawalContainer.sol";
 import {ExoCapsuleStorage} from "../storage/ExoCapsuleStorage.sol";
 
 import {IBeaconChainOracle} from "@beacon-oracle/contracts/src/IBeaconChainOracle.sol";
-import {Initializable} from "@openzeppelin-upgradeable/contracts/proxy/utils/Initializable.sol";
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 
 contract ExoCapsule is Initializable, ExoCapsuleStorage, IExoCapsule {
 

--- a/src/core/ExocoreGateway.sol
+++ b/src/core/ExocoreGateway.sol
@@ -19,10 +19,10 @@ import {OAppCoreUpgradeable} from "../lzApp/OAppCoreUpgradeable.sol";
 import {IOAppCore} from "@layerzero-v2/oapp/contracts/oapp/interfaces/IOAppCore.sol";
 import {OptionsBuilder} from "@layerzero-v2/oapp/contracts/oapp/libs/OptionsBuilder.sol";
 import {ILayerZeroReceiver} from "@layerzero-v2/protocol/contracts/interfaces/ILayerZeroReceiver.sol";
-import {OwnableUpgradeable} from "@openzeppelin-upgradeable/contracts/access/OwnableUpgradeable.sol";
-import {Initializable} from "@openzeppelin-upgradeable/contracts/proxy/utils/Initializable.sol";
-import {PausableUpgradeable} from "@openzeppelin-upgradeable/contracts/utils/PausableUpgradeable.sol";
-import {ReentrancyGuardUpgradeable} from "@openzeppelin-upgradeable/contracts/utils/ReentrancyGuardUpgradeable.sol";
+import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
+import {ReentrancyGuardUpgradeable} from "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
 
 contract ExocoreGateway is
     Initializable,
@@ -59,7 +59,7 @@ contract ExocoreGateway is
         exocoreValidatorSetAddress = exocoreValidatorSetAddress_;
 
         _initializeWhitelistFunctionSelectors();
-        __Ownable_init_unchained(exocoreValidatorSetAddress);
+        _transferOwnership(exocoreValidatorSetAddress);
         __OAppCore_init_unchained(exocoreValidatorSetAddress);
         __Pausable_init_unchained();
         __ReentrancyGuard_init_unchained();

--- a/src/core/LSTRestakingController.sol
+++ b/src/core/LSTRestakingController.sol
@@ -5,8 +5,8 @@ import {ILSTRestakingController} from "../interfaces/ILSTRestakingController.sol
 import {IVault} from "../interfaces/IVault.sol";
 import {BaseRestakingController} from "./BaseRestakingController.sol";
 
-import {PausableUpgradeable} from "@openzeppelin-upgradeable/contracts/utils/PausableUpgradeable.sol";
-import {ReentrancyGuardUpgradeable} from "@openzeppelin-upgradeable/contracts/utils/ReentrancyGuardUpgradeable.sol";
+import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
+import {ReentrancyGuardUpgradeable} from "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
 
 abstract contract LSTRestakingController is
     PausableUpgradeable,

--- a/src/core/NativeRestakingController.sol
+++ b/src/core/NativeRestakingController.sol
@@ -7,8 +7,8 @@ import {ValidatorContainer} from "../libraries/ValidatorContainer.sol";
 import {BaseRestakingController} from "./BaseRestakingController.sol";
 import {ExoCapsule} from "./ExoCapsule.sol";
 
-import {PausableUpgradeable} from "@openzeppelin-upgradeable/contracts/utils/PausableUpgradeable.sol";
-import {ReentrancyGuardUpgradeable} from "@openzeppelin-upgradeable/contracts/utils/ReentrancyGuardUpgradeable.sol";
+import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
+import {ReentrancyGuardUpgradeable} from "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
 import {Create2} from "@openzeppelin/contracts/utils/Create2.sol";
 
 abstract contract NativeRestakingController is

--- a/src/core/Vault.sol
+++ b/src/core/Vault.sol
@@ -4,9 +4,9 @@ import {ILSTRestakingController} from "../interfaces/ILSTRestakingController.sol
 import {IVault} from "../interfaces/IVault.sol";
 import {VaultStorage} from "../storage/VaultStorage.sol";
 
-import {IERC20} from "@openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
-import {SafeERC20} from "@openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
-import {Initializable} from "@openzeppelin-upgradeable/contracts/proxy/utils/Initializable.sol";
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 contract Vault is Initializable, VaultStorage, IVault {
 

--- a/src/interfaces/ICustomProxyAdmin.sol
+++ b/src/interfaces/ICustomProxyAdmin.sol
@@ -1,7 +1,6 @@
 pragma solidity ^0.8.19;
 
-import {ITransparentUpgradeableProxy} from
-    "@openzeppelin-contracts/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {ITransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 
 interface ICustomProxyAdmin {
 

--- a/src/lzApp/OAppCoreUpgradeable.sol
+++ b/src/lzApp/OAppCoreUpgradeable.sol
@@ -3,7 +3,7 @@
 pragma solidity ^0.8.20;
 
 import {ILayerZeroEndpointV2, IOAppCore} from "@layerzero-v2/oapp/contracts/oapp/interfaces/IOAppCore.sol";
-import {OwnableUpgradeable} from "@openzeppelin-upgradeable/contracts/access/OwnableUpgradeable.sol";
+import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 
 /**
  * @title OAppCoreUpgradeable
@@ -37,7 +37,7 @@ abstract contract OAppCoreUpgradeable is IOAppCore, OwnableUpgradeable {
             revert InvalidDelegate();
         }
         endpoint.setDelegate(_delegate);
-        __Ownable_init_unchained(_delegate);
+        _transferOwnership(_delegate);
     }
 
     /**

--- a/src/lzApp/OAppSenderUpgradeable.sol
+++ b/src/lzApp/OAppSenderUpgradeable.sol
@@ -8,7 +8,7 @@ import {
     MessagingParams,
     MessagingReceipt
 } from "@layerzero-v2/protocol/contracts/interfaces/ILayerZeroEndpointV2.sol";
-import {IERC20, SafeERC20} from "@openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
+import {IERC20, SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 /**
  * @title OAppSenderUpgradeable

--- a/src/storage/BootstrapStorage.sol
+++ b/src/storage/BootstrapStorage.sol
@@ -6,7 +6,7 @@ import {IOperatorRegistry} from "../interfaces/IOperatorRegistry.sol";
 
 import {IVault} from "../interfaces/IVault.sol";
 import {GatewayStorage} from "./GatewayStorage.sol";
-import {IBeacon} from "@openzeppelin-contracts/contracts/proxy/beacon/IBeacon.sol";
+import {IBeacon} from "@openzeppelin/contracts/proxy/beacon/IBeacon.sol";
 import {Create2} from "@openzeppelin/contracts/utils/Create2.sol";
 
 // BootstrapStorage should inherit from GatewayStorage since it exists

--- a/src/storage/ClientChainGatewayStorage.sol
+++ b/src/storage/ClientChainGatewayStorage.sol
@@ -4,7 +4,7 @@ import {IETHPOSDeposit} from "../interfaces/IETHPOSDeposit.sol";
 import {IExoCapsule} from "../interfaces/IExoCapsule.sol";
 import {BootstrapStorage} from "../storage/BootstrapStorage.sol";
 
-import {IBeacon} from "@openzeppelin-contracts/contracts/proxy/beacon/IBeacon.sol";
+import {IBeacon} from "@openzeppelin/contracts/proxy/beacon/IBeacon.sol";
 
 contract ClientChainGatewayStorage is BootstrapStorage {
 

--- a/src/storage/VaultStorage.sol
+++ b/src/storage/VaultStorage.sol
@@ -1,7 +1,7 @@
 pragma solidity ^0.8.19;
 
 import {ILSTRestakingController} from "../interfaces/ILSTRestakingController.sol";
-import {IERC20} from "@openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 contract VaultStorage {
 

--- a/test/foundry/DepositThenDelegateTo.t.sol
+++ b/test/foundry/DepositThenDelegateTo.t.sol
@@ -12,7 +12,7 @@ import "./ExocoreDeployer.t.sol";
 import {OptionsBuilder} from "@layerzero-v2/oapp/contracts/oapp/libs/OptionsBuilder.sol";
 import "@layerzero-v2/protocol/contracts/libs/AddressCast.sol";
 import "@layerzerolabs/lz-evm-protocol-v2/contracts/libs/GUID.sol";
-import {IERC20} from "@openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "forge-std/Test.sol";
 
 import "forge-std/console.sol";

--- a/test/foundry/ExocoreDeployer.t.sol
+++ b/test/foundry/ExocoreDeployer.t.sol
@@ -4,11 +4,11 @@ import "@beacon-oracle/contracts/src/EigenLayerBeaconOracle.sol";
 import "@layerzero-v2/protocol/contracts/interfaces/ILayerZeroEndpointV2.sol";
 import "@layerzero-v2/protocol/contracts/libs/AddressCast.sol";
 import "@layerzerolabs/lz-evm-protocol-v2/contracts/libs/GUID.sol";
-import "@openzeppelin-contracts/contracts/proxy/beacon/IBeacon.sol";
-import "@openzeppelin-contracts/contracts/proxy/beacon/UpgradeableBeacon.sol";
-import "@openzeppelin-contracts/contracts/proxy/transparent/ProxyAdmin.sol";
-import "@openzeppelin-contracts/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
-import "@openzeppelin-contracts/contracts/token/ERC20/presets/ERC20PresetFixedSupply.sol";
+import "@openzeppelin/contracts/proxy/beacon/IBeacon.sol";
+import "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";
+import "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+import "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import "@openzeppelin/contracts/token/ERC20/presets/ERC20PresetFixedSupply.sol";
 import "@openzeppelin/contracts/utils/Create2.sol";
 
 import "forge-std/Test.sol";

--- a/test/foundry/unit/Bootstrap.t.sol
+++ b/test/foundry/unit/Bootstrap.t.sol
@@ -17,9 +17,9 @@ import {GatewayStorage} from "src/storage/GatewayStorage.sol";
 
 import "@layerzerolabs/lz-evm-protocol-v2/contracts/libs/GUID.sol";
 
-import {IBeacon} from "@openzeppelin-contracts/contracts/proxy/beacon/IBeacon.sol";
-import {UpgradeableBeacon} from "@openzeppelin-contracts/contracts/proxy/beacon/UpgradeableBeacon.sol";
-import "@openzeppelin-contracts/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {IBeacon} from "@openzeppelin/contracts/proxy/beacon/IBeacon.sol";
+import {UpgradeableBeacon} from "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";
+import "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 
 import "@openzeppelin/contracts/utils/Create2.sol";
 import "forge-std/Test.sol";

--- a/test/foundry/unit/ClientChainGateway.t.sol
+++ b/test/foundry/unit/ClientChainGateway.t.sol
@@ -5,13 +5,14 @@ import "@beacon-oracle/contracts/src/EigenLayerBeaconOracle.sol";
 import "@layerzero-v2/protocol/contracts/interfaces/ILayerZeroEndpointV2.sol";
 import "@layerzero-v2/protocol/contracts/libs/AddressCast.sol";
 import "@layerzerolabs/lz-evm-protocol-v2/contracts/libs/GUID.sol";
-import "@openzeppelin-contracts/contracts/proxy/beacon/IBeacon.sol";
-import "@openzeppelin-contracts/contracts/proxy/beacon/UpgradeableBeacon.sol";
-import "@openzeppelin-contracts/contracts/proxy/transparent/ProxyAdmin.sol";
-import "@openzeppelin-contracts/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
-import "@openzeppelin-contracts/contracts/token/ERC20/presets/ERC20PresetFixedSupply.sol";
-import "@openzeppelin-upgradeable/contracts/access/OwnableUpgradeable.sol";
-import "@openzeppelin-upgradeable/contracts/utils/PausableUpgradeable.sol";
+
+import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
+import "@openzeppelin/contracts/proxy/beacon/IBeacon.sol";
+import "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";
+import "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+import "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import "@openzeppelin/contracts/token/ERC20/presets/ERC20PresetFixedSupply.sol";
 
 import "forge-std/Test.sol";
 import "forge-std/console.sol";
@@ -210,19 +211,19 @@ contract Pausable is SetUp {
         vm.startPrank(exocoreValidatorSet.addr);
         clientGateway.pause();
 
-        vm.expectRevert(PausableUpgradeable.EnforcedPause.selector);
+        vm.expectRevert("Pausable: paused");
         clientGateway.claim(address(restakeToken), uint256(1), deployer.addr);
 
-        vm.expectRevert(PausableUpgradeable.EnforcedPause.selector);
+        vm.expectRevert("Pausable: paused");
         clientGateway.delegateTo(operatorAddress, address(restakeToken), uint256(1));
 
-        vm.expectRevert(PausableUpgradeable.EnforcedPause.selector);
+        vm.expectRevert("Pausable: paused");
         clientGateway.deposit(address(restakeToken), uint256(1));
 
-        vm.expectRevert(PausableUpgradeable.EnforcedPause.selector);
+        vm.expectRevert("Pausable: paused");
         clientGateway.withdrawPrincipalFromExocore(address(restakeToken), uint256(1));
 
-        vm.expectRevert(PausableUpgradeable.EnforcedPause.selector);
+        vm.expectRevert("Pausable: paused");
         clientGateway.undelegateFrom(operatorAddress, address(restakeToken), uint256(1));
     }
 
@@ -285,7 +286,7 @@ contract AddWhitelistTokens is SetUp {
         address[] memory whitelistTokens = new address[](2);
 
         vm.startPrank(deployer.addr);
-        vm.expectRevert(abi.encodeWithSelector(OwnableUpgradeable.OwnableUnauthorizedAccount.selector, deployer.addr));
+        vm.expectRevert("Ownable: caller is not the owner");
         clientGateway.addWhitelistTokens(whitelistTokens);
     }
 
@@ -294,7 +295,7 @@ contract AddWhitelistTokens is SetUp {
         clientGateway.pause();
 
         address[] memory whitelistTokens = new address[](2);
-        vm.expectRevert(PausableUpgradeable.EnforcedPause.selector);
+        vm.expectRevert("Pausable: paused");
         clientGateway.addWhitelistTokens(whitelistTokens);
     }
 

--- a/test/foundry/unit/CustomProxyAdmin.t.sol
+++ b/test/foundry/unit/CustomProxyAdmin.t.sol
@@ -7,8 +7,8 @@ import {ICustomProxyAdmin} from "src/interfaces/ICustomProxyAdmin.sol";
 import "forge-std/Test.sol";
 import "forge-std/console.sol";
 
-import "@openzeppelin-contracts/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
-import {Initializable} from "@openzeppelin-upgradeable/contracts/proxy/utils/Initializable.sol";
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 
 contract StorageOld {
 

--- a/test/foundry/unit/ExoCapsule.t.sol
+++ b/test/foundry/unit/ExoCapsule.t.sol
@@ -1,9 +1,9 @@
 pragma solidity ^0.8.19;
 
 import "@beacon-oracle/contracts/src/EigenLayerBeaconOracle.sol";
-import "@openzeppelin-contracts/contracts/proxy/transparent/ProxyAdmin.sol";
-import "@openzeppelin-contracts/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
-import "@openzeppelin-contracts/contracts/token/ERC20/presets/ERC20PresetFixedSupply.sol";
+import "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+import "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import "@openzeppelin/contracts/token/ERC20/presets/ERC20PresetFixedSupply.sol";
 import "forge-std/Test.sol";
 import "forge-std/console.sol";
 

--- a/test/foundry/unit/ExocoreGateway.t.sol
+++ b/test/foundry/unit/ExocoreGateway.t.sol
@@ -7,9 +7,9 @@ import "src/interfaces/precompiles/IDelegation.sol";
 
 import "@layerzero-v2/protocol/contracts/libs/AddressCast.sol";
 import "@layerzerolabs/lz-evm-protocol-v2/contracts/libs/GUID.sol";
-import "@openzeppelin-contracts/contracts/proxy/transparent/ProxyAdmin.sol";
-import "@openzeppelin-contracts/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
-import "@openzeppelin-contracts/contracts/token/ERC20/presets/ERC20PresetFixedSupply.sol";
+import "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+import "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import "@openzeppelin/contracts/token/ERC20/presets/ERC20PresetFixedSupply.sol";
 import "forge-std/Test.sol";
 import "forge-std/console.sol";
 import "src/core/ClientChainGateway.sol";
@@ -48,9 +48,6 @@ contract SetUp is Test {
     event Unpaused(address account);
     event ExocorePrecompileError(address indexed precompile, uint64 nonce);
     event MessageSent(GatewayStorage.Action indexed act, bytes32 packetId, uint64 nonce, uint256 nativeFee);
-
-    error EnforcedPause();
-    error ExpectedPause();
 
     function setUp() public virtual {
         players.push(Player({privateKey: uint256(0x1), addr: vm.addr(uint256(0x1))}));
@@ -150,7 +147,7 @@ contract Pausable is SetUp {
         exocoreGateway.pause();
 
         vm.prank(address(exocoreLzEndpoint));
-        vm.expectRevert(EnforcedPause.selector);
+        vm.expectRevert("Pausable: paused");
         exocoreGateway.lzReceive(
             Origin(clientChainId, address(clientGateway).toBytes32(), uint64(1)),
             bytes32(0),
@@ -234,7 +231,7 @@ contract RegisterOrUpdateClientChain is SetUp {
         _prepareClientChainData();
 
         vm.startPrank(deployer.addr);
-        vm.expectRevert(abi.encodeWithSelector(OwnableUpgradeable.OwnableUnauthorizedAccount.selector, deployer.addr));
+        vm.expectRevert("Ownable: caller is not the owner");
         exocoreGateway.registerOrUpdateClientChain(
             anotherClientChain, peer, addressLength, name, metaInfo, signatureType
         );
@@ -246,7 +243,7 @@ contract RegisterOrUpdateClientChain is SetUp {
 
         _prepareClientChainData();
 
-        vm.expectRevert(PausableUpgradeable.EnforcedPause.selector);
+        vm.expectRevert("Pausable: paused");
         vm.startPrank(exocoreValidatorSet.addr);
         exocoreGateway.registerOrUpdateClientChain(
             anotherClientChain, peer, addressLength, name, metaInfo, signatureType
@@ -352,7 +349,7 @@ contract SetPeer is SetUp {
         vm.stopPrank();
 
         vm.startPrank(deployer.addr);
-        vm.expectRevert(abi.encodeWithSelector(OwnableUpgradeable.OwnableUnauthorizedAccount.selector, deployer.addr));
+        vm.expectRevert("Ownable: caller is not the owner");
         exocoreGateway.setPeer(anotherClientChain, newPeer);
     }
 
@@ -386,7 +383,7 @@ contract AddWhitelistTokens is SetUp {
         uint256 nativeFee = exocoreGateway.quote(clientChainId, new bytes(messageLength));
 
         vm.startPrank(deployer.addr);
-        vm.expectRevert(abi.encodeWithSelector(OwnableUpgradeable.OwnableUnauthorizedAccount.selector, deployer.addr));
+        vm.expectRevert("Ownable: caller is not the owner");
         exocoreGateway.addWhitelistTokens{value: nativeFee}(
             clientChainId, whitelistTokens, decimals, tvlLimits, names, metaData
         );
@@ -400,7 +397,7 @@ contract AddWhitelistTokens is SetUp {
 
         uint256 messageLength = TOKEN_ADDRESS_BYTES_LENGTH * whitelistTokens.length + 2;
         uint256 nativeFee = exocoreGateway.quote(clientChainId, new bytes(messageLength));
-        vm.expectRevert(PausableUpgradeable.EnforcedPause.selector);
+        vm.expectRevert("Pausable: paused");
         exocoreGateway.addWhitelistTokens{value: nativeFee}(
             clientChainId, whitelistTokens, decimals, tvlLimits, names, metaData
         );
@@ -543,7 +540,7 @@ contract UpdateWhitelistTokens is SetUp {
         _prepareInputs(2);
 
         vm.startPrank(deployer.addr);
-        vm.expectRevert(abi.encodeWithSelector(OwnableUpgradeable.OwnableUnauthorizedAccount.selector, deployer.addr));
+        vm.expectRevert("Ownable: caller is not the owner");
         exocoreGateway.updateWhitelistedTokens(clientChainId, whitelistTokens, decimals, tvlLimits, names, metaData);
     }
 
@@ -553,7 +550,7 @@ contract UpdateWhitelistTokens is SetUp {
 
         _prepareInputs(2);
 
-        vm.expectRevert(PausableUpgradeable.EnforcedPause.selector);
+        vm.expectRevert("Pausable: paused");
         exocoreGateway.updateWhitelistedTokens(clientChainId, whitelistTokens, decimals, tvlLimits, names, metaData);
     }
 

--- a/test/mocks/ExocoreGatewayMock.sol
+++ b/test/mocks/ExocoreGatewayMock.sol
@@ -18,10 +18,10 @@ import {ExocoreGatewayStorage} from "src/storage/ExocoreGatewayStorage.sol";
 import {IOAppCore} from "@layerzero-v2/oapp/contracts/oapp/interfaces/IOAppCore.sol";
 import {OptionsBuilder} from "@layerzero-v2/oapp/contracts/oapp/libs/OptionsBuilder.sol";
 import {ILayerZeroReceiver} from "@layerzero-v2/protocol/contracts/interfaces/ILayerZeroReceiver.sol";
-import {OwnableUpgradeable} from "@openzeppelin-upgradeable/contracts/access/OwnableUpgradeable.sol";
-import {Initializable} from "@openzeppelin-upgradeable/contracts/proxy/utils/Initializable.sol";
-import {PausableUpgradeable} from "@openzeppelin-upgradeable/contracts/utils/PausableUpgradeable.sol";
-import {ReentrancyGuardUpgradeable} from "@openzeppelin-upgradeable/contracts/utils/ReentrancyGuardUpgradeable.sol";
+import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
+import {ReentrancyGuardUpgradeable} from "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
 import {OAppCoreUpgradeable} from "src/lzApp/OAppCoreUpgradeable.sol";
 
 contract ExocoreGatewayMock is
@@ -82,7 +82,7 @@ contract ExocoreGatewayMock is
         exocoreValidatorSetAddress = exocoreValidatorSetAddress_;
 
         _initializeWhitelistFunctionSelectors();
-        __Ownable_init_unchained(exocoreValidatorSetAddress);
+        _transferOwnership(exocoreValidatorSetAddress);
         __OAppCore_init_unchained(exocoreValidatorSetAddress);
         __Pausable_init_unchained();
     }

--- a/test/mocks/deps.sol
+++ b/test/mocks/deps.sol
@@ -1,5 +1,5 @@
 pragma solidity ^0.8.20;
 
-import "@openzeppelin-contracts/contracts/proxy/transparent/ProxyAdmin.sol";
-import "@openzeppelin-contracts/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
-import "@openzeppelin-contracts/contracts/token/ERC20/presets/ERC20PresetFixedSupply.sol";
+import "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+import "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import "@openzeppelin/contracts/token/ERC20/presets/ERC20PresetFixedSupply.sol";


### PR DESCRIPTION
## Description

closes: #44 

As described in #44 , v5 contracts use new op codes like `tload` and `tstore` that are introduced in `cancun` upgrade and not supported by `paris`. For compatibility, we should downgrade openzeppelin-contracts-upgradeable from v5.0.2 to v4.9.6.

- [x] downgrade submodule `openzeppelin-contracts-upgradeable` from v5.0.2 to v4.9.6
- [x] unify remapping:
   ```
   @openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/
   @openzeppelin/contracts-upgradeable/=lib/openzeppelin-contracts-upgradeable/contracts/
   ```
- [x] fix failed tests



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated OpenZeppelin contract paths to reflect new package structure.
  - Corrected import paths across multiple scripts and contracts.
  - Simplified and standardized initialization calls for ownership transfer.

This update ensures consistent and accurate references to dependencies, reducing potential errors and improving maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->