### PR TITLE
refactor: use `_handleResponse` to handle all responses to reduce code size

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -376,7 +376,8 @@
         "@nomicfoundation/hardhat-foundry": "^1.1.1",
         "@nomicfoundation/hardhat-toolbox": "^4.0.0",
         "hardhat": "^2.19.3",
-        "mocha": "^10.2.0"
+        "mocha": "^10.2.0",
+        "solhint": "^5.0.1"
       },
       "optionalDependencies": {
         "fsevents": "^2.3.3"
@@ -386,6 +387,43 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.0.tgz",
       "integrity": "sha512-nA9XHtlAkYfJxY7bce8DcN7eKxWWCWkU+1GR9d+U6MbNpfwQp8TI7vqOsBsMcHoT4mBu2kypKoSKnghEzOOq5Q=="
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.7.tgz",
+      "integrity": "sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/highlight": "^7.24.7",
+        "picocolors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
+      "integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/highlight": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.7.tgz",
+      "integrity": "sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.24.7",
+        "chalk": "^2.4.2",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
     },
     "node_modules/@chainsafe/as-sha256": {
       "version": "0.3.1",
@@ -1736,6 +1774,47 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@pnpm/config.env-replace": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@pnpm/config.env-replace/-/config.env-replace-1.1.0.tgz",
+      "integrity": "sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.22.0"
+      }
+    },
+    "node_modules/@pnpm/network.ca-file": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@pnpm/network.ca-file/-/network.ca-file-1.0.2.tgz",
+      "integrity": "sha512-YcPQ8a0jwYU9bTdJDpXjMi7Brhkr1mXsXrUJvjqM2mQDgkRiz8jFaQGOdaLxgjtUfQgZhKy/O3cG/YwmgKaxLA==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "4.2.10"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      }
+    },
+    "node_modules/@pnpm/network.ca-file/node_modules/graceful-fs": {
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+      "dev": true
+    },
+    "node_modules/@pnpm/npm-conf": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@pnpm/npm-conf/-/npm-conf-2.2.2.tgz",
+      "integrity": "sha512-UA91GwWPhFExt3IizW6bOeY/pQ0BkuNwKjk9iQW9KqxluGCrg4VenZ0/L+2Y0+ZOtme72EVvg6v0zo3AMQRCeA==",
+      "dev": true,
+      "dependencies": {
+        "@pnpm/config.env-replace": "^1.1.0",
+        "@pnpm/network.ca-file": "^1.0.1",
+        "config-chain": "^1.1.11"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@scure/base": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.5.tgz",
@@ -1916,12 +1995,36 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
+    "node_modules/@sindresorhus/is": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-5.6.0.tgz",
+      "integrity": "sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
     "node_modules/@solidity-parser/parser": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.14.5.tgz",
       "integrity": "sha512-6dKnHZn7fg/iQATVEzqyUOyEidbn05q7YA2mQ9hC0MMXhhV3/JrsxmFSYZAcr7j1yUP700LLhTruvJ3MiQmjJg==",
       "dependencies": {
         "antlr4ts": "^0.5.0-alpha.4"
+      }
+    },
+    "node_modules/@szmarczak/http-timer": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-5.0.1.tgz",
+      "integrity": "sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==",
+      "dev": true,
+      "dependencies": {
+        "defer-to-connect": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=14.16"
       }
     },
     "node_modules/@tsconfig/node10": {
@@ -2025,6 +2128,12 @@
         "@types/minimatch": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/http-cache-semantics": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
+      "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==",
+      "dev": true
     },
     "node_modules/@types/lru-cache": {
       "version": "5.1.1",
@@ -2262,6 +2371,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/antlr4": {
+      "version": "4.13.1-patch-1",
+      "resolved": "https://registry.npmjs.org/antlr4/-/antlr4-4.13.1-patch-1.tgz",
+      "integrity": "sha512-OjFLWWLzDMV9rdFhpvroCWR4ooktNg9/nvVYSA5z28wuVpU36QUNuioR1XLnQtcjVlf8npjyz593PxnU/f/Cow==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/antlr4ts": {
       "version": "0.5.0-alpha.4",
       "resolved": "https://registry.npmjs.org/antlr4ts/-/antlr4ts-0.5.0-alpha.4.tgz",
@@ -2325,6 +2443,12 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/ast-parents": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/ast-parents/-/ast-parents-0.0.1.tgz",
+      "integrity": "sha512-XHusKxKz3zoYk1ic8Un640joHbFMhbqneyoZfoKnEGtf2ey9Uh/IdpcQplODdO/kENaMIWsD0nJm4+wX3UNLHA==",
+      "dev": true
     },
     "node_modules/astral-regex": {
       "version": "2.0.0",
@@ -2552,6 +2676,33 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/cacheable-lookup": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
+      "integrity": "sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.16"
+      }
+    },
+    "node_modules/cacheable-request": {
+      "version": "10.2.14",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-10.2.14.tgz",
+      "integrity": "sha512-zkDT5WAF4hSSoUgyfg5tFIxz8XQK+25W/TLVojJTMKBaxevLBBtLxgqguAuVQB8PVW79FVjHcU+GJ9tVbDZ9mQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/http-cache-semantics": "^4.0.2",
+        "get-stream": "^6.0.1",
+        "http-cache-semantics": "^4.1.1",
+        "keyv": "^4.5.3",
+        "mimic-response": "^4.0.0",
+        "normalize-url": "^8.0.0",
+        "responselike": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
@@ -2568,6 +2719,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/camelcase": {
@@ -2915,6 +3075,16 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/config-chain": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+      "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+      "dev": true,
+      "dependencies": {
+        "ini": "^1.3.4",
+        "proto-list": "~1.2.1"
+      }
+    },
     "node_modules/cookie": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
@@ -2927,6 +3097,32 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+    },
+    "node_modules/cosmiconfig": {
+      "version": "8.3.6",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
+      "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
+      "dev": true,
+      "dependencies": {
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0",
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
     },
     "node_modules/crc-32": {
       "version": "1.2.2",
@@ -3022,6 +3218,33 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
       "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA=="
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/decompress-response/node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/deep-eql": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
@@ -3045,6 +3268,15 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
+    },
+    "node_modules/defer-to-connect": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+      "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/define-data-property": {
       "version": "1.1.4",
@@ -3174,6 +3406,15 @@
       "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
       }
     },
     "node_modules/es-define-property": {
@@ -3551,6 +3792,12 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
+    "node_modules/fast-diff": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
+      "dev": true
+    },
     "node_modules/fast-glob": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
@@ -3565,6 +3812,12 @@
       "engines": {
         "node": ">=8.6.0"
       }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
@@ -3658,6 +3911,15 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/form-data-encoder": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-2.1.4.tgz",
+      "integrity": "sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.17"
       }
     },
     "node_modules/fp-ts": {
@@ -3757,6 +4019,18 @@
         "node": ">=4"
       }
     },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ghost-testrpc": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/ghost-testrpc/-/ghost-testrpc-0.0.2.tgz",
@@ -3850,6 +4124,31 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/got": {
+      "version": "12.6.1",
+      "resolved": "https://registry.npmjs.org/got/-/got-12.6.1.tgz",
+      "integrity": "sha512-mThBblvlAF1d4O5oqyvN+ZxLAYwIJK7bpMxgYqPD9okW0C3qm5FFn7k811QrcuEBwaogR3ngOFoCfs6mRv7teQ==",
+      "dev": true,
+      "dependencies": {
+        "@sindresorhus/is": "^5.2.0",
+        "@szmarczak/http-timer": "^5.0.1",
+        "cacheable-lookup": "^7.0.0",
+        "cacheable-request": "^10.2.8",
+        "decompress-response": "^6.0.0",
+        "form-data-encoder": "^2.1.2",
+        "get-stream": "^6.0.1",
+        "http2-wrapper": "^2.1.10",
+        "lowercase-keys": "^3.0.0",
+        "p-cancelable": "^3.0.0",
+        "responselike": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/got?sponsor=1"
       }
     },
     "node_modules/graceful-fs": {
@@ -4195,6 +4494,12 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/http-cache-semantics": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
+      "dev": true
+    },
     "node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -4222,6 +4527,19 @@
       "version": "10.17.60",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
       "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
+    },
+    "node_modules/http2-wrapper": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.1.tgz",
+      "integrity": "sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==",
+      "dev": true,
+      "dependencies": {
+        "quick-lru": "^5.1.1",
+        "resolve-alpn": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      }
     },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
@@ -4277,6 +4595,31 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.4.tgz",
       "integrity": "sha512-fsXeu4J4i6WNWSikpI88v/PcVflZz+6kMhUfIwc5SY+poQRPnaf5V7qds6SUyUN3cVxEzuCab7QIoLOQ+DQ1wA=="
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "dev": true,
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-fresh/node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/indent-string": {
       "version": "4.0.0",
@@ -4335,6 +4678,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -4503,6 +4852,12 @@
       "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
       "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
     },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
     "node_modules/js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -4513,6 +4868,18 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
@@ -4552,6 +4919,15 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
     "node_modules/kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -4566,6 +4942,21 @@
       "integrity": "sha512-TED5xi9gGQjGpNnvRWknrwAB1eL5GciPfVFOt3Vk1OJCVDQbzuSfrF3hkUQKlsgKrG1F+0t5W0m+Fje1jIt8rw==",
       "optionalDependencies": {
         "graceful-fs": "^4.1.9"
+      }
+    },
+    "node_modules/latest-version": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-7.0.0.tgz",
+      "integrity": "sha512-KvNT4XqAMzdcL6ka6Tl3i2lYeFDgXNCuIX+xNx6ZMVR1dFq+idXd9FLKNMOIx0t9mJ9/HudyX4oZWXZQ0UJHeg==",
+      "dev": true,
+      "dependencies": {
+        "package-json": "^8.1.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/level": {
@@ -4615,6 +5006,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true
     },
     "node_modules/locate-path": {
       "version": "2.0.0",
@@ -4740,6 +5137,18 @@
         "get-func-name": "^2.0.1"
       }
     },
+    "node_modules/lowercase-keys": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
+      "integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/lru_map": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
@@ -4844,6 +5253,18 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-4.0.0.tgz",
+      "integrity": "sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/minimalistic-assert": {
@@ -5166,6 +5587,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/normalize-url": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.0.1.tgz",
+      "integrity": "sha512-IO9QvjUMWxPQQhs60oOu10CRkWCiZzSUkzbXGGV9pviYl1fXYcvkzQ5jV9z8Y6un8ARoVRl4EtC6v6jNqbaJ/w==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/number-to-bn": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
@@ -5242,6 +5675,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/p-cancelable": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-3.0.0.tgz",
+      "integrity": "sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
     "node_modules/p-limit": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
@@ -5286,10 +5728,70 @@
         "node": ">=4"
       }
     },
+    "node_modules/package-json": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/package-json/-/package-json-8.1.1.tgz",
+      "integrity": "sha512-cbH9IAIJHNj9uXi196JVsRlt7cHKak6u/e6AkL/bkRelZ7rlL3X1YKxsZwa36xipOEKAsdtmaG6aAJoM1fx2zA==",
+      "dev": true,
+      "dependencies": {
+        "got": "^12.1.0",
+        "registry-auth-token": "^5.0.1",
+        "registry-url": "^6.0.0",
+        "semver": "^7.3.7"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/package-json/node_modules/semver": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/parse-cache-control": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
       "integrity": "sha512-60zvsJReQPX5/QP0Kzfd/VrpjScIQ7SHBW6bFCYfEP+fp0Eppr1SHhIO5nd1PjZtvclzSzES9D/p5nFJurwfWg=="
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/path-exists": {
       "version": "3.0.0",
@@ -5343,6 +5845,12 @@
         "node": ">=0.12"
       }
     },
+    "node_modules/picocolors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
+      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==",
+      "dev": true
+    },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -5360,6 +5868,15 @@
       "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/pluralize": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -5404,6 +5921,12 @@
       "dependencies": {
         "asap": "~2.0.6"
       }
+    },
+    "node_modules/proto-list": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+      "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
+      "dev": true
     },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
@@ -5451,6 +5974,18 @@
         }
       ]
     },
+    "node_modules/quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -5471,6 +6006,30 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/readable-stream": {
@@ -5527,6 +6086,33 @@
         "node": ">=6"
       }
     },
+    "node_modules/registry-auth-token": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-5.0.2.tgz",
+      "integrity": "sha512-o/3ikDxtXaA59BmZuZrJZDJv8NMDGSj+6j6XaeBmHw8eY1i1qd9+6H+LjVvQXx3HN6aRCGa1cUdJ9RaJZUugnQ==",
+      "dev": true,
+      "dependencies": {
+        "@pnpm/npm-conf": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/registry-url": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-6.0.1.tgz",
+      "integrity": "sha512-+crtS5QjFRqFCoQmvGduwYWEBng99ZvmFvF+cUJkGYF1L1BfU8C6Zp9T7f5vPAwyLkUExpvK+ANVZmGU49qi4Q==",
+      "dev": true,
+      "dependencies": {
+        "rc": "1.2.8"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/req-cwd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/req-cwd/-/req-cwd-2.0.0.tgz",
@@ -5576,12 +6162,33 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/resolve-alpn": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+      "dev": true
+    },
     "node_modules/resolve-from": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
       "integrity": "sha512-GnlH6vxLymXJNMBo7XP1fJIzBFbdYt49CuTwmB/6N53t+kMPRMFKz783LlQ4tv28XoQfMWinAJX6WCGf2IlaIw==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/responselike": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-3.0.0.tgz",
+      "integrity": "sha512-40yHxbNcl2+rzXvZuVkrYohathsSJlMTXKryG5y8uciHv1+xDLHQpgjG64JUO9nrEq2jGLH6IZ8BcZyw3wrweg==",
+      "dev": true,
+      "dependencies": {
+        "lowercase-keys": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/reusify": {
@@ -6018,6 +6625,198 @@
         "semver": "bin/semver"
       }
     },
+    "node_modules/solhint": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/solhint/-/solhint-5.0.1.tgz",
+      "integrity": "sha512-QeQLS9HGCnIiibt+xiOa/+MuP7BWz9N7C5+Mj9pLHshdkNhuo3AzCpWmjfWVZBUuwIUO3YyCRVIcYLR3YOKGfg==",
+      "dev": true,
+      "dependencies": {
+        "@solidity-parser/parser": "^0.18.0",
+        "ajv": "^6.12.6",
+        "antlr4": "^4.13.1-patch-1",
+        "ast-parents": "^0.0.1",
+        "chalk": "^4.1.2",
+        "commander": "^10.0.0",
+        "cosmiconfig": "^8.0.0",
+        "fast-diff": "^1.2.0",
+        "glob": "^8.0.3",
+        "ignore": "^5.2.4",
+        "js-yaml": "^4.1.0",
+        "latest-version": "^7.0.0",
+        "lodash": "^4.17.21",
+        "pluralize": "^8.0.0",
+        "semver": "^7.5.2",
+        "strip-ansi": "^6.0.1",
+        "table": "^6.8.1",
+        "text-table": "^0.2.0"
+      },
+      "bin": {
+        "solhint": "solhint.js"
+      },
+      "optionalDependencies": {
+        "prettier": "^2.8.3"
+      }
+    },
+    "node_modules/solhint/node_modules/@solidity-parser/parser": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.18.0.tgz",
+      "integrity": "sha512-yfORGUIPgLck41qyN7nbwJRAx17/jAIXCTanHOJZhB6PJ1iAk/84b/xlsVKFSyNyLXIj0dhppoE0+CRws7wlzA==",
+      "dev": true
+    },
+    "node_modules/solhint/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/solhint/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/solhint/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/solhint/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/solhint/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/solhint/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/solhint/node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/solhint/node_modules/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/solhint/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/solhint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "node_modules/solhint/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/solhint/node_modules/semver": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/solhint/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/solidity-coverage": {
       "version": "0.8.5",
       "resolved": "https://registry.npmjs.org/solidity-coverage/-/solidity-coverage-0.8.5.tgz",
@@ -6353,6 +7152,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true
     },
     "node_modules/then-request": {
       "version": "6.0.2",

--- a/package.json
+++ b/package.json
@@ -379,7 +379,8 @@
     "@nomicfoundation/hardhat-foundry": "^1.1.1",
     "@nomicfoundation/hardhat-toolbox": "^4.0.0",
     "hardhat": "^2.19.3",
-    "mocha": "^10.2.0"
+    "mocha": "^10.2.0",
+    "solhint": "^5.0.1"
   },
   "scripts": {
     "test": "mocha"

--- a/src/core/ClientChainGateway.sol
+++ b/src/core/ClientChainGateway.sol
@@ -63,16 +63,6 @@ contract ClientChainGateway is
 
         require(owner_ != address(0), "ClientChainGateway: contract owner should not be empty");
 
-        _registeredResponseHooks[Action.REQUEST_DEPOSIT] = this.afterReceiveDepositResponse.selector;
-        _registeredResponseHooks[Action.REQUEST_WITHDRAW_PRINCIPAL_FROM_EXOCORE] =
-            this.afterReceiveWithdrawPrincipalResponse.selector;
-        _registeredResponseHooks[Action.REQUEST_DELEGATE_TO] = this.afterReceiveDelegateResponse.selector;
-        _registeredResponseHooks[Action.REQUEST_UNDELEGATE_FROM] = this.afterReceiveUndelegateResponse.selector;
-        _registeredResponseHooks[Action.REQUEST_WITHDRAW_REWARD_FROM_EXOCORE] =
-            this.afterReceiveWithdrawRewardResponse.selector;
-        _registeredResponseHooks[Action.REQUEST_DEPOSIT_THEN_DELEGATE_TO] =
-            this.afterReceiveDepositThenDelegateToResponse.selector;
-
         _whiteListFunctionSelectors[Action.REQUEST_ADD_WHITELIST_TOKENS] =
             this.afterReceiveAddWhitelistTokensRequest.selector;
 
@@ -106,10 +96,6 @@ contract ClientChainGateway is
 
     function unpause() external onlyOwner {
         _unpause();
-    }
-
-    function addWhitelistTokens(address[] calldata) external onlyOwner whenNotPaused {
-        revert("this function is not supported for client chain, please register on Exocore");
     }
 
     // implementation of ITokenWhitelister

--- a/src/core/ClientGatewayLzReceiver.sol
+++ b/src/core/ClientGatewayLzReceiver.sol
@@ -99,8 +99,7 @@ abstract contract ClientGatewayLzReceiver is PausableUpgradeable, OAppReceiverUp
                 success = _decodeBasicResponse(response);
             } else {
                 // otherwise expect BalanceResponse, which means deposit-then-delegate operation
-                (address token, address staker, string memory operator, uint256 amount) =
-                    abi.decode(cachedRequest, (address, address, string, uint256));
+                (address token, address staker,,) = abi.decode(cachedRequest, (address, address, string, uint256));
                 (success, updatedBalance) = _decodeBalanceResponse(response);
 
                 IVault vault = _getVault(token);

--- a/src/core/ClientGatewayLzReceiver.sol
+++ b/src/core/ClientGatewayLzReceiver.sol
@@ -79,11 +79,11 @@ abstract contract ClientGatewayLzReceiver is PausableUpgradeable, OAppReceiverUp
             (success, updatedBalance) = _decodeBalanceResponse(response);
 
             if (_isPrincipalType(requestAct)) {
-                if (_isDeposit(requestAct) && !success) {
-                    revert DepositShouldNotFailOnExocore(token, staker);
-                }
-
-                if (success) {
+                // we assume deposit request must always be successful, thus we should always update balance for deposit
+                // request
+                // Notice: Action.REQUEST_DEPOSIT_THEN_DELEGATE_TO is a special operation that is not atomic, since
+                // deposit should always be successful while delegate could fail for some cases
+                if (success || _isDeposit(requestAct)) {
                     _updatePrincipalAssetState(requestAct, token, staker, amount, updatedBalance);
                 }
             } else {

--- a/src/core/ClientGatewayLzReceiver.sol
+++ b/src/core/ClientGatewayLzReceiver.sol
@@ -36,27 +36,7 @@ abstract contract ClientGatewayLzReceiver is PausableUpgradeable, OAppReceiverUp
 
         Action act = Action(uint8(payload[0]));
         if (act == Action.RESPOND) {
-            uint64 requestId = uint64(bytes8(payload[1:9]));
-
-            Action requestAct = _registeredRequestActions[requestId];
-            bytes4 hookSelector = _registeredResponseHooks[requestAct];
-            if (hookSelector == bytes4(0)) {
-                revert UnsupportedResponse(act);
-            }
-
-            bytes memory requestPayload = _registeredRequests[requestId];
-            if (requestPayload.length == 0) {
-                revert UnexpectedResponse(requestId);
-            }
-
-            (bool success, bytes memory reason) =
-                address(this).call(abi.encodePacked(hookSelector, abi.encode(requestPayload, payload[9:])));
-            if (!success) {
-                revert RequestOrResponseExecuteFailed(act, _origin.nonce, reason);
-            }
-
-            delete _registeredRequestActions[requestId];
-            delete _registeredRequests[requestId];
+            _handleResponse(payload);
         } else {
             bytes4 selector_ = _whiteListFunctionSelectors[act];
             if (selector_ == bytes4(0)) {
@@ -81,121 +61,141 @@ abstract contract ClientGatewayLzReceiver is PausableUpgradeable, OAppReceiverUp
         return inboundNonce[srcEid][sender] + 1;
     }
 
-    function afterReceiveDepositResponse(bytes memory requestPayload, bytes calldata responsePayload)
-        public
-        onlyCalledFromThis
-    {
-        (address token, address depositor, uint256 amount) = abi.decode(requestPayload, (address, address, uint256));
+    // Though this function makes external calls to contract Vault or ExoCapsule, we just update their state variables
+    // and don't make
+    // calls to other contracts that do not belong to Exocore.
+    // And (success, updatedBalance) would be updated according to response message.
+    // slither-disable-next-line reentrancy-no-eth
+    function _handleResponse(bytes calldata response) internal {
+        (uint64 requestId, Action requestAct, bytes memory cachedRequest) = _getCachedRequestForResponse(response);
 
-        bool success = (uint8(bytes1(responsePayload[0])) == 1);
-        uint256 lastlyUpdatedPrincipalBalance = uint256(bytes32(responsePayload[1:]));
+        bool success = false;
+        uint256 updatedBalance;
+        if (_isAssetOperationRequest(requestAct)) {
+            (address token, address staker, uint256 amount) = abi.decode(cachedRequest, (address, address, uint256));
+            (success, updatedBalance) = _decodeBalanceResponse(response);
 
-        if (!success) {
-            revert DepositShouldNotFailOnExocore(token, depositor);
-        }
+            if (_isPrincipalType(requestAct)) {
+                if (_isDeposit(requestAct) && !success) {
+                    revert DepositShouldNotFailOnExocore(token, staker);
+                }
 
-        if (token == VIRTUAL_STAKED_ETH_ADDRESS) {
-            IExoCapsule capsule = _getCapsule(depositor);
-            capsule.updatePrincipalBalance(lastlyUpdatedPrincipalBalance);
-        } else {
-            IVault vault = _getVault(token);
-            vault.updatePrincipalBalance(depositor, lastlyUpdatedPrincipalBalance);
-        }
-
-        emit DepositResult(success, token, depositor, amount);
-    }
-
-    function afterReceiveWithdrawPrincipalResponse(bytes memory requestPayload, bytes calldata responsePayload)
-        public
-        onlyCalledFromThis
-    {
-        (address token, address withdrawer, uint256 unlockPrincipalAmount) =
-            abi.decode(requestPayload, (address, address, uint256));
-
-        bool success = (uint8(bytes1(responsePayload[0])) == 1);
-        uint256 lastlyUpdatedPrincipalBalance = uint256(bytes32(responsePayload[1:33]));
-
-        if (!success) {
-            emit WithdrawFailedOnExocore(token, withdrawer);
-        } else {
-            if (token == VIRTUAL_STAKED_ETH_ADDRESS) {
-                IExoCapsule capsule = _getCapsule(withdrawer);
-
-                capsule.updatePrincipalBalance(lastlyUpdatedPrincipalBalance);
-                capsule.updateWithdrawableBalance(unlockPrincipalAmount);
+                if (success) {
+                    _updatePrincipleAssetState(requestAct, token, staker, amount, updatedBalance);
+                }
             } else {
-                IVault vault = _getVault(token);
+                // otherwise this is an operation aimed at reward
+                if (success) {
+                    IVault vault = _getVault(token);
 
-                vault.updatePrincipalBalance(withdrawer, lastlyUpdatedPrincipalBalance);
-                vault.updateWithdrawableBalance(withdrawer, unlockPrincipalAmount, 0);
+                    vault.updateRewardBalance(staker, updatedBalance);
+                    if (_isWithdrawal(requestAct)) {
+                        vault.updateWithdrawableBalance(staker, 0, amount);
+                    }
+                }
             }
+        } else if (_isStakingOperationRequest(requestAct)) {
+            if (_expectBasicResponse(requestAct)) {
+                success = _decodeBasicResponse(response);
+            } else {
+                // otherwise expect BalanceResponse, which means deposit-then-delegate operation
+                (address token, address staker, string memory operator, uint256 amount) =
+                    abi.decode(cachedRequest, (address, address, string, uint256));
+                (success, updatedBalance) = _decodeBalanceResponse(response);
 
-            emit WithdrawPrincipalResult(success, token, withdrawer, unlockPrincipalAmount);
-        }
-    }
-
-    function afterReceiveWithdrawRewardResponse(bytes memory requestPayload, bytes calldata responsePayload)
-        public
-        onlyCalledFromThis
-    {
-        (address token, address withdrawer, uint256 unlockRewardAmount) =
-            abi.decode(requestPayload, (address, address, uint256));
-
-        bool success = (uint8(bytes1(responsePayload[0])) == 1);
-        uint256 lastlyUpdatedRewardBalance = uint256(bytes32(responsePayload[1:33]));
-        if (success) {
-            IVault vault = _getVault(token);
-
-            vault.updateRewardBalance(withdrawer, lastlyUpdatedRewardBalance);
-            vault.updateWithdrawableBalance(withdrawer, 0, unlockRewardAmount);
+                IVault vault = _getVault(token);
+                vault.updatePrincipalBalance(staker, updatedBalance);
+            }
+        } else {
+            revert UnsupportedResponse(requestAct);
         }
 
-        emit WithdrawRewardResult(success, token, withdrawer, unlockRewardAmount);
+        delete _registeredRequestActions[requestId];
+        delete _registeredRequests[requestId];
+
+        emit RequestFinished(requestAct, requestId, success);
     }
 
-    function afterReceiveDelegateResponse(bytes memory requestPayload, bytes calldata responsePayload)
-        public
-        onlyCalledFromThis
-    {
-        (address token, address delegator, string memory operator, uint256 amount) =
-            abi.decode(requestPayload, (address, address, string, uint256));
+    function _getCachedRequestForResponse(bytes calldata response) internal returns (uint64, Action, bytes memory) {
+        uint64 requestId = uint64(bytes8(response[1:9]));
 
-        bool success = (uint8(bytes1(responsePayload[0])) == 1);
+        bytes memory cachedRequest = _registeredRequests[requestId];
+        if (cachedRequest.length == 0) {
+            revert UnexpectedResponse(requestId);
+        }
+        Action requestAct = _registeredRequestActions[requestId];
 
-        emit DelegateResult(success, delegator, operator, token, amount);
+        return (requestId, requestAct, cachedRequest);
     }
 
-    function afterReceiveUndelegateResponse(bytes memory requestPayload, bytes calldata responsePayload)
-        public
-        onlyCalledFromThis
-    {
-        (address token, address undelegator, string memory operator, uint256 amount) =
-            abi.decode(requestPayload, (address, address, string, uint256));
-
-        bool success = (uint8(bytes1(responsePayload[0])) == 1);
-
-        emit UndelegateResult(success, undelegator, operator, token, amount);
+    function _isAssetOperationRequest(Action action) internal pure returns (bool) {
+        return action == Action.REQUEST_DEPOSIT || action == Action.REQUEST_WITHDRAW_PRINCIPAL_FROM_EXOCORE
+            || action == Action.REQUEST_WITHDRAW_REWARD_FROM_EXOCORE;
     }
 
-    function afterReceiveDepositThenDelegateToResponse(bytes memory requestPayload, bytes calldata responsePayload)
-        public
-        onlyCalledFromThis
-    {
-        (address token, address delegator, string memory operator, uint256 amount) =
-            abi.decode(requestPayload, (address, address, string, uint256));
+    function _isStakingOperationRequest(Action action) internal pure returns (bool) {
+        return action == Action.REQUEST_DELEGATE_TO || action == Action.REQUEST_UNDELEGATE_FROM
+            || action == Action.REQUEST_DEPOSIT_THEN_DELEGATE_TO;
+    }
 
-        bool delegateSuccess = (uint8(bytes1(responsePayload[0])) == 1);
-        uint256 lastlyUpdatedPrincipalBalance = uint256(bytes32(responsePayload[1:]));
+    function _expectBasicResponse(Action action) internal pure returns (bool) {
+        return action == Action.REQUEST_DELEGATE_TO || action == Action.REQUEST_UNDELEGATE_FROM;
+    }
 
+    function _expectBalanceResponse(Action action) internal pure returns (bool) {
+        return action == Action.REQUEST_DEPOSIT || action == Action.REQUEST_WITHDRAW_PRINCIPAL_FROM_EXOCORE
+            || action == Action.REQUEST_WITHDRAW_REWARD_FROM_EXOCORE || action == Action.REQUEST_DEPOSIT_THEN_DELEGATE_TO;
+    }
+
+    function _isPrincipalType(Action action) internal pure returns (bool) {
+        return action == Action.REQUEST_DEPOSIT || action == Action.REQUEST_WITHDRAW_PRINCIPAL_FROM_EXOCORE
+            || action == Action.REQUEST_DEPOSIT_THEN_DELEGATE_TO;
+    }
+
+    function _isWithdrawal(Action action) internal pure returns (bool) {
+        return action == Action.REQUEST_WITHDRAW_PRINCIPAL_FROM_EXOCORE
+            || action == Action.REQUEST_WITHDRAW_REWARD_FROM_EXOCORE;
+    }
+
+    function _isDeposit(Action action) internal pure returns (bool) {
+        return action == Action.REQUEST_DEPOSIT || action == Action.REQUEST_DEPOSIT_THEN_DELEGATE_TO;
+    }
+
+    function _decodeBalanceResponse(bytes calldata response) internal pure returns (bool, uint256) {
+        bool success = (uint8(bytes1(response[9])) == 1);
+        uint256 updatedBalance = uint256(bytes32(response[10:]));
+
+        return (success, updatedBalance);
+    }
+
+    function _decodeBasicResponse(bytes calldata response) internal pure returns (bool) {
+        bool success = (uint8(bytes1(response[9])) == 1);
+
+        return success;
+    }
+
+    function _updatePrincipleAssetState(
+        Action requestAct,
+        address token,
+        address staker,
+        uint256 amount,
+        uint256 updatedBalance
+    ) internal {
         if (token == VIRTUAL_STAKED_ETH_ADDRESS) {
-            IExoCapsule capsule = _getCapsule(delegator);
-            capsule.updatePrincipalBalance(lastlyUpdatedPrincipalBalance);
+            IExoCapsule capsule = _getCapsule(staker);
+
+            capsule.updatePrincipalBalance(updatedBalance);
+            if (_isWithdrawal(requestAct)) {
+                capsule.updateWithdrawableBalance(amount);
+            }
         } else {
             IVault vault = _getVault(token);
-            vault.updatePrincipalBalance(delegator, lastlyUpdatedPrincipalBalance);
-        }
 
-        emit DepositThenDelegateResult(delegateSuccess, delegator, operator, token, amount);
+            vault.updatePrincipalBalance(staker, updatedBalance);
+            if (_isWithdrawal(requestAct)) {
+                vault.updateWithdrawableBalance(staker, amount, 0);
+            }
+        }
     }
 
     // Though `_deployVault` would make external call to newly created `Vault` contract and initialize it,

--- a/src/core/ClientGatewayLzReceiver.sol
+++ b/src/core/ClientGatewayLzReceiver.sol
@@ -141,11 +141,6 @@ abstract contract ClientGatewayLzReceiver is PausableUpgradeable, OAppReceiverUp
         return action == Action.REQUEST_DELEGATE_TO || action == Action.REQUEST_UNDELEGATE_FROM;
     }
 
-    function _expectBalanceResponse(Action action) internal pure returns (bool) {
-        return action == Action.REQUEST_DEPOSIT || action == Action.REQUEST_WITHDRAW_PRINCIPAL_FROM_EXOCORE
-            || action == Action.REQUEST_WITHDRAW_REWARD_FROM_EXOCORE || action == Action.REQUEST_DEPOSIT_THEN_DELEGATE_TO;
-    }
-
     function _isPrincipalType(Action action) internal pure returns (bool) {
         return action == Action.REQUEST_DEPOSIT || action == Action.REQUEST_WITHDRAW_PRINCIPAL_FROM_EXOCORE
             || action == Action.REQUEST_DEPOSIT_THEN_DELEGATE_TO;

--- a/src/core/ClientGatewayLzReceiver.sol
+++ b/src/core/ClientGatewayLzReceiver.sol
@@ -84,7 +84,8 @@ abstract contract ClientGatewayLzReceiver is PausableUpgradeable, OAppReceiverUp
                     _updatePrincipalAssetState(requestAct, token, staker, amount, updatedBalance);
                 }
             } else {
-                // otherwise this is an operation aimed at reward
+                // otherwise this is an operation aimed at reward since Action.REQUEST_WITHDRAW_REWARD_FROM_EXOCORE is
+                // the only asset operation request that deals with reward instead of principal
                 if (success) {
                     IVault vault = _getVault(token);
 

--- a/src/core/ClientGatewayLzReceiver.sol
+++ b/src/core/ClientGatewayLzReceiver.sol
@@ -81,7 +81,7 @@ abstract contract ClientGatewayLzReceiver is PausableUpgradeable, OAppReceiverUp
                 }
 
                 if (success) {
-                    _updatePrincipleAssetState(requestAct, token, staker, amount, updatedBalance);
+                    _updatePrincipalAssetState(requestAct, token, staker, amount, updatedBalance);
                 }
             } else {
                 // otherwise this is an operation aimed at reward
@@ -173,7 +173,7 @@ abstract contract ClientGatewayLzReceiver is PausableUpgradeable, OAppReceiverUp
         return success;
     }
 
-    function _updatePrincipleAssetState(
+    function _updatePrincipalAssetState(
         Action requestAct,
         address token,
         address staker,

--- a/src/core/ExocoreGateway.sol
+++ b/src/core/ExocoreGateway.sol
@@ -296,6 +296,8 @@ contract ExocoreGateway is
         }
 
         _sendInterchainMsg(srcChainId, Action.RESPOND, abi.encodePacked(lzNonce, success, updatedBalance), true);
+
+        emit DepositResult(true, bytes32(token), bytes32(depositor), amount);
     }
 
     function requestWithdrawPrincipal(uint32 srcChainId, uint64 lzNonce, bytes calldata payload)
@@ -310,15 +312,19 @@ contract ExocoreGateway is
         bytes memory withdrawer = payload[32:64];
         uint256 amount = uint256(bytes32(payload[64:96]));
 
+        bool result = false;
         try ASSETS_CONTRACT.withdrawPrincipal(srcChainId, token, withdrawer, amount) returns (
             bool success, uint256 updatedBalance
         ) {
+            result = success;
             _sendInterchainMsg(srcChainId, Action.RESPOND, abi.encodePacked(lzNonce, success, updatedBalance), true);
         } catch {
             emit ExocorePrecompileError(ASSETS_PRECOMPILE_ADDRESS, lzNonce);
 
             _sendInterchainMsg(srcChainId, Action.RESPOND, abi.encodePacked(lzNonce, false, uint256(0)), true);
         }
+
+        emit WithdrawPrincipalResult(result, bytes32(token), bytes32(withdrawer), amount);
     }
 
     function requestWithdrawReward(uint32 srcChainId, uint64 lzNonce, bytes calldata payload)
@@ -331,15 +337,19 @@ contract ExocoreGateway is
         bytes memory withdrawer = payload[32:64];
         uint256 amount = uint256(bytes32(payload[64:96]));
 
+        bool result = false;
         try CLAIM_REWARD_CONTRACT.claimReward(srcChainId, token, withdrawer, amount) returns (
             bool success, uint256 updatedBalance
         ) {
+            result = success;
             _sendInterchainMsg(srcChainId, Action.RESPOND, abi.encodePacked(lzNonce, success, updatedBalance), true);
         } catch {
             emit ExocorePrecompileError(CLAIM_REWARD_PRECOMPILE_ADDRESS, lzNonce);
 
             _sendInterchainMsg(srcChainId, Action.RESPOND, abi.encodePacked(lzNonce, false, uint256(0)), true);
         }
+
+        emit WithdrawRewardResult(result, bytes32(token), bytes32(withdrawer), amount);
     }
 
     function requestDelegateTo(uint32 srcChainId, uint64 lzNonce, bytes calldata payload) public onlyCalledFromThis {
@@ -350,14 +360,18 @@ contract ExocoreGateway is
         bytes memory operator = payload[64:106];
         uint256 amount = uint256(bytes32(payload[106:138]));
 
+        bool result = false;
         try DELEGATION_CONTRACT.delegateToThroughClientChain(srcChainId, lzNonce, token, delegator, operator, amount)
         returns (bool success) {
+            result = success;
             _sendInterchainMsg(srcChainId, Action.RESPOND, abi.encodePacked(lzNonce, success), true);
         } catch {
             emit ExocorePrecompileError(DELEGATION_PRECOMPILE_ADDRESS, lzNonce);
 
             _sendInterchainMsg(srcChainId, Action.RESPOND, abi.encodePacked(lzNonce, false), true);
         }
+
+        emit DelegateResult(result, bytes32(token), bytes32(delegator), string(operator), amount);
     }
 
     function requestUndelegateFrom(uint32 srcChainId, uint64 lzNonce, bytes calldata payload)
@@ -371,15 +385,19 @@ contract ExocoreGateway is
         bytes memory operator = payload[64:106];
         uint256 amount = uint256(bytes32(payload[106:138]));
 
+        bool result = false;
         try DELEGATION_CONTRACT.undelegateFromThroughClientChain(
             srcChainId, lzNonce, token, delegator, operator, amount
         ) returns (bool success) {
+            result = success;
             _sendInterchainMsg(srcChainId, Action.RESPOND, abi.encodePacked(lzNonce, success), true);
         } catch {
             emit ExocorePrecompileError(DELEGATION_PRECOMPILE_ADDRESS, lzNonce);
 
             _sendInterchainMsg(srcChainId, Action.RESPOND, abi.encodePacked(lzNonce, false), true);
         }
+
+        emit UndelegateResult(result, bytes32(token), bytes32(delegator), string(operator), amount);
     }
 
     function requestDepositThenDelegateTo(uint32 srcChainId, uint64 lzNonce, bytes calldata payload)
@@ -399,12 +417,14 @@ contract ExocoreGateway is
         // for example, you cannot index a bytes memory result from the requestDepositTo call,
         // if you were to modify it to return bytes and then process them here.
 
+        bool result = false;
         (bool success, uint256 updatedBalance) = ASSETS_CONTRACT.depositTo(srcChainId, token, depositor, amount);
         if (!success) {
             revert DepositRequestShouldNotFail(srcChainId, lzNonce);
         }
         try DELEGATION_CONTRACT.delegateToThroughClientChain(srcChainId, lzNonce, token, depositor, operator, amount)
         returns (bool delegateSuccess) {
+            result = delegateSuccess;
             _sendInterchainMsg(
                 srcChainId, Action.RESPOND, abi.encodePacked(lzNonce, delegateSuccess, updatedBalance), true
             );
@@ -412,6 +432,9 @@ contract ExocoreGateway is
             emit ExocorePrecompileError(DELEGATION_PRECOMPILE_ADDRESS, lzNonce);
             _sendInterchainMsg(srcChainId, Action.RESPOND, abi.encodePacked(lzNonce, false, updatedBalance), true);
         }
+
+        emit DepositResult(true, bytes32(token), bytes32(depositor), amount);
+        emit DelegateResult(result, bytes32(token), bytes32(depositor), string(operator), amount);
     }
 
     function _validatePayloadLength(bytes calldata payload, uint256 expectedLength, Action action) private pure {

--- a/src/core/ExocoreGateway.sol
+++ b/src/core/ExocoreGateway.sol
@@ -422,6 +422,8 @@ contract ExocoreGateway is
         if (!success) {
             revert DepositRequestShouldNotFail(srcChainId, lzNonce);
         }
+        emit DepositResult(true, bytes32(token), bytes32(depositor), amount);
+
         try DELEGATION_CONTRACT.delegateToThroughClientChain(srcChainId, lzNonce, token, depositor, operator, amount)
         returns (bool delegateSuccess) {
             result = delegateSuccess;
@@ -432,8 +434,6 @@ contract ExocoreGateway is
             emit ExocorePrecompileError(DELEGATION_PRECOMPILE_ADDRESS, lzNonce);
             _sendInterchainMsg(srcChainId, Action.RESPOND, abi.encodePacked(lzNonce, false, updatedBalance), true);
         }
-
-        emit DepositResult(true, bytes32(token), bytes32(depositor), amount);
         emit DelegateResult(result, bytes32(token), bytes32(depositor), string(operator), amount);
     }
 

--- a/src/interfaces/IClientChainGateway.sol
+++ b/src/interfaces/IClientChainGateway.sol
@@ -1,20 +1,12 @@
 pragma solidity ^0.8.19;
 
 import {INativeRestakingController} from "../interfaces/INativeRestakingController.sol";
-
-import {ITokenWhitelister} from "../interfaces/ITokenWhitelister.sol";
 import {ILSTRestakingController} from "./ILSTRestakingController.sol";
 
 import {IOAppCore} from "@layerzero-v2/oapp/contracts/oapp/interfaces/IOAppCore.sol";
 import {IOAppReceiver} from "@layerzero-v2/oapp/contracts/oapp/interfaces/IOAppReceiver.sol";
 
-interface IClientChainGateway is
-    ITokenWhitelister,
-    IOAppReceiver,
-    IOAppCore,
-    ILSTRestakingController,
-    INativeRestakingController
-{
+interface IClientChainGateway is IOAppReceiver, IOAppCore, ILSTRestakingController, INativeRestakingController {
 
     function quote(bytes memory _message) external view returns (uint256 nativeFee);
 

--- a/src/storage/BootstrapStorage.sol
+++ b/src/storage/BootstrapStorage.sol
@@ -301,23 +301,6 @@ contract BootstrapStorage is GatewayStorage {
     );
 
     /**
-     * @notice Emitted when a deposit + delegation is made.
-     * @dev This event is triggered whenever a delegator deposits and then delegates tokens to an operator.
-     * @param delegateSuccess Whether the delegation succeeded (deposits always succeed!).
-     * @param delegator The address of the delegator, on this chain.
-     * @param delegatee The Exocore address of the operator.
-     * @param token The address of the token being delegated, on this chain.
-     * @param delegatedAmount The amount of the token delegated.
-     */
-    event DepositThenDelegateResult(
-        bool indexed delegateSuccess,
-        address indexed delegator,
-        string indexed delegatee,
-        address token,
-        uint256 delegatedAmount
-    );
-
-    /**
      * @notice Emitted after the Exocore chain is bootstrapped.
      * @dev This event is triggered after the Exocore chain is bootstrapped, indicating that
      * the contract has successfully transitioned to the Client Chain Gateway logic. Exocore

--- a/src/storage/ClientChainGatewayStorage.sol
+++ b/src/storage/ClientChainGatewayStorage.sol
@@ -16,7 +16,6 @@ contract ClientChainGatewayStorage is BootstrapStorage {
     mapping(address => IExoCapsule) public ownerToCapsule;
     mapping(uint64 => bytes) internal _registeredRequests;
     mapping(uint64 => Action) internal _registeredRequestActions;
-    mapping(Action => bytes4) internal _registeredResponseHooks;
 
     // immutable state variables
     address public immutable BEACON_ORACLE_ADDRESS;
@@ -42,7 +41,7 @@ contract ClientChainGatewayStorage is BootstrapStorage {
 
     /* ----------------------------- restaking      ----------------------------- */
     event ClaimSucceeded(address token, address recipient, uint256 amount);
-    event WithdrawRewardResult(bool indexed success, address indexed token, address indexed withdrawer, uint256 amount);
+    event RequestFinished(Action indexed action, uint64 indexed requestId, bool indexed success);
 
     /* -------------------------------------------------------------------------- */
     /*                                   Errors                                   */

--- a/src/storage/ExocoreGatewayStorage.sol
+++ b/src/storage/ExocoreGatewayStorage.sol
@@ -31,6 +31,19 @@ contract ExocoreGatewayStorage is GatewayStorage {
     event WhitelistTokenAdded(uint32 clientChainId, bytes32 token);
     event WhitelistTokenUpdated(uint32 clientChainId, bytes32 token);
 
+    /* --------- asset operations results and staking operations results -------- */
+    event WithdrawRewardResult(bool indexed success, bytes32 indexed token, bytes32 indexed withdrawer, uint256 amount);
+    event DepositResult(bool indexed success, bytes32 indexed token, bytes32 indexed depositor, uint256 amount);
+    event WithdrawPrincipalResult(
+        bool indexed success, bytes32 indexed token, bytes32 indexed withdrawer, uint256 amount
+    );
+    event DelegateResult(
+        bool indexed success, bytes32 indexed token, bytes32 indexed delegator, string operator, uint256 amount
+    );
+    event UndelegateResult(
+        bool indexed success, bytes32 indexed token, bytes32 indexed undelegator, string operator, uint256 amount
+    );
+
     error RequestExecuteFailed(Action act, uint64 nonce, bytes reason);
     error PrecompileCallFailed(bytes4 selector_, bytes reason);
     error InvalidRequestLength(Action act, uint256 expectedLength, uint256 actualLength);

--- a/src/storage/GatewayStorage.sol
+++ b/src/storage/GatewayStorage.sol
@@ -17,13 +17,13 @@ contract GatewayStorage {
     mapping(Action => bytes4) internal _whiteListFunctionSelectors;
     mapping(uint32 eid => mapping(bytes32 sender => uint64 nonce)) public inboundNonce;
 
+    uint256[40] private __gap;
+
     event MessageSent(Action indexed act, bytes32 packetId, uint64 nonce, uint256 nativeFee);
 
     error UnsupportedRequest(Action act);
     error UnexpectedSourceChain(uint32 unexpectedSrcEndpointId);
     error UnexpectedInboundNonce(uint64 expectedNonce, uint64 actualNonce);
-
-    uint256[40] private __gap;
 
     function _verifyAndUpdateNonce(uint32 srcChainId, bytes32 srcAddress, uint64 nonce) internal {
         uint64 expectedNonce = inboundNonce[srcChainId][srcAddress] + 1;

--- a/test/foundry/DepositThenDelegateTo.t.sol
+++ b/test/foundry/DepositThenDelegateTo.t.sol
@@ -134,6 +134,11 @@ contract DepositThenDelegateToTest is ExocoreDeployer {
         uint256 responseNativeFee = exocoreGateway.quote(clientChainId, responsePayload);
         bytes32 responseId = generateUID(responseLzNonce, false);
 
+        // deposit request is firstly handled and its event is firstly emitted
+        vm.expectEmit(address(exocoreGateway));
+        emit DepositResult(true, bytes32(bytes20(address(restakeToken))), bytes32(bytes20(delegator)), delegateAmount);
+
+        // secondly delegate request is handled
         vm.expectEmit(DELEGATION_PRECOMPILE_ADDRESS);
         emit DelegateRequestProcessed(
             clientChainId,
@@ -158,7 +163,6 @@ contract DepositThenDelegateToTest is ExocoreDeployer {
         emit MessageSent(GatewayStorage.Action.RESPOND, responseId, responseLzNonce, responseNativeFee);
 
         vm.expectEmit(address(exocoreGateway));
-        emit DepositResult(true, bytes32(bytes20(address(restakeToken))), bytes32(bytes20(delegator)), delegateAmount);
         emit DelegateResult(
             true, bytes32(bytes20(address(restakeToken))), bytes32(bytes20(delegator)), operatorAddress, delegateAmount
         );

--- a/test/foundry/ExocoreDeployer.t.sol
+++ b/test/foundry/ExocoreDeployer.t.sol
@@ -103,6 +103,7 @@ contract ExocoreDeployer is Test {
     event NewPacket(uint32, address, bytes32, uint64, bytes);
     event WhitelistTokenAdded(address _token);
     event VaultCreated(address underlyingToken, address vault);
+    event RequestFinished(GatewayStorage.Action indexed action, uint64 indexed requestId, bool indexed success);
 
     function setUp() public virtual {
         players.push(Player({privateKey: uint256(0x1), addr: vm.addr(uint256(0x1))}));

--- a/test/foundry/unit/ClientChainGateway.t.sol
+++ b/test/foundry/unit/ClientChainGateway.t.sol
@@ -273,34 +273,3 @@ contract Initialize is SetUp {
     }
 
 }
-
-contract AddWhitelistTokens is SetUp {
-
-    using stdStorage for StdStorage;
-
-    function test_RevertWhen_CallerNotOwner() public {
-        address[] memory whitelistTokens = new address[](2);
-
-        vm.startPrank(deployer.addr);
-        vm.expectRevert("Ownable: caller is not the owner");
-        clientGateway.addWhitelistTokens(whitelistTokens);
-    }
-
-    function test_RevertWhen_Paused() public {
-        vm.startPrank(exocoreValidatorSet.addr);
-        clientGateway.pause();
-
-        address[] memory whitelistTokens = new address[](2);
-        vm.expectRevert("Pausable: paused");
-        clientGateway.addWhitelistTokens(whitelistTokens);
-    }
-
-    function test_Revert_NotSupported() public {
-        address[] memory whitelistTokens = new address[](2);
-
-        vm.startPrank(exocoreValidatorSet.addr);
-        vm.expectRevert("this function is not supported for client chain, please register on Exocore");
-        clientGateway.addWhitelistTokens(whitelistTokens);
-    }
-
-}


### PR DESCRIPTION
## Description

closes: #42 

before refactoring, the code size of `ClientChainGateway` has exceeded the size limit (24576 bytes):
```bash
 Contract                      | Size (B) | Margin (B) |
|-------------------------------|----------|------------|
| Address                       |       86 |     24,490 |
| AddressCast                   |       86 |     24,490 |
| AddressUpgradeable            |       86 |     24,490 |
| AssetsMock                    |    3,329 |     21,247 |
| BeaconChainProofs             |       86 |     24,490 |
| BeaconProxyBytecode           |    2,614 |     21,962 |
| BitMaps                       |       86 |     24,490 |
| Bootstrap                     |   22,100 |      2,476 |
| BootstrapStorage              |    3,031 |     21,545 |
| BytesLib                      |       86 |     24,490 |
| CalldataBytesLib              |       86 |     24,490 |
| ClaimRewardMock               |      624 |     23,952 |
| ClientChainGateway            |   24,788 |       -212 |
```

One of the approaches to reduce code size is to removing redundant functions, so I tried to use a single internal function `_handleResponse` to deal with all kinds of responses, instead of the original response hook functions that are public(public functions seem occupy more space). After refactoring, the code size has been significantly reduced:
```bash
| Contract                      | Size (B) | Margin (B) |
|-------------------------------|----------|------------|
| Address                       |       86 |     24,490 |
| AddressCast                   |       86 |     24,490 |
| AddressUpgradeable            |       86 |     24,490 |
| AssetsMock                    |    3,329 |     21,247 |
| BeaconChainProofs             |       86 |     24,490 |
| BeaconProxyBytecode           |    2,614 |     21,962 |
| BitMaps                       |       86 |     24,490 |
| Bootstrap                     |   22,100 |      2,476 |
| BootstrapStorage              |    3,031 |     21,545 |
| BytesLib                      |       86 |     24,490 |
| CalldataBytesLib              |       86 |     24,490 |
| ClaimRewardMock               |      624 |     23,952 |
| ClientChainGateway            |   22,725 |      1,851 |
```
Roughly 2 kb size is saved after refactoring. Removing `ITokenWhitelister` also helps with this issue. So we might be able to find more approaches to optimize the code size while this PR aims to solve the most urgent issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced handling of responses within the application, improving the organization and readability of code flow.
  
- **Refactor**
  - Consolidated and refactored response processing into a centralized function for better code management.

- **Events**
  - Introduced new event emissions for asset and staking operations, providing more detailed information on transaction outcomes.

- **Interface Updates**
  - Simplified interface inheritance by removing unnecessary extensions.

- **Bug Fixes**
  - Improved the robustness of the response handling logic to ensure accurate state updates and processing checks.

- **Dependency Update**
  - Added Solhint to the project dependencies for improved Solidity code quality and best practices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->