### PR TITLE
fix(ci): downgrade node due to nodejs/node#53902

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,7 +22,14 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: '22'
+          # Node 22.5 has a bug
+          # https://github.com/nodejs/node/pull/53904
+          # TODO: Once a version with the bug fix (above) is released,
+          # the version pin can be moved back to 22
+          node-version: '22.4'
+
+      - name: Clear npm cache
+        run: npm cache clean --force
 
       - name: Install Solhint
         run: npm install --save-dev solhint


### PR DESCRIPTION
A bug in node version 22.5.0 has caused the CI to fail. While a patch has been merged, a release is still awaited. This PR works around that by pinning the node version to one that does not contain the bug.

Once there is a new release, the pinned part (`.4`) can be removed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Downgraded Node.js version in workflows to 22.4 due to a bug in version 22.5.
  - Added a step to clear the npm cache in the workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->