### PR TITLE
fix: merkleize typo

### DIFF
--- a/src/core/ExoCapsule.sol
+++ b/src/core/ExoCapsule.sol
@@ -267,7 +267,7 @@ contract ExoCapsule is ReentrancyGuardUpgradeable, ExoCapsuleStorage, IExoCapsul
         view
     {
         bytes32 beaconBlockRoot = getBeaconBlockRoot(proof.beaconBlockTimestamp);
-        bytes32 validatorContainerRoot = validatorContainer.merklelizeValidatorContainer();
+        bytes32 validatorContainerRoot = validatorContainer.merkleizeValidatorContainer();
         bool valid = validatorContainerRoot.isValidValidatorContainerRoot(
             proof.validatorContainerRootProof,
             proof.validatorIndex,
@@ -285,7 +285,7 @@ contract ExoCapsule is ReentrancyGuardUpgradeable, ExoCapsuleStorage, IExoCapsul
         BeaconChainProofs.WithdrawalProof calldata proof
     ) internal view {
         // To-do check withdrawalContainer length is valid
-        bytes32 withdrawalContainerRoot = withdrawalContainer.merklelizeWithdrawalContainer();
+        bytes32 withdrawalContainerRoot = withdrawalContainer.merkleizeWithdrawalContainer();
         bool valid = withdrawalContainerRoot.isValidWithdrawalContainerRoot(proof);
         if (!valid) {
             revert InvalidWithdrawalContainer(withdrawalContainer.getValidatorIndex());

--- a/src/libraries/ValidatorContainer.sol
+++ b/src/libraries/ValidatorContainer.sol
@@ -53,7 +53,7 @@ library ValidatorContainer {
         return validatorContainer[7].fromLittleEndianUint64();
     }
 
-    function merklelizeValidatorContainer(bytes32[] calldata validatorContainer) internal pure returns (bytes32) {
+    function merkleizeValidatorContainer(bytes32[] calldata validatorContainer) internal pure returns (bytes32) {
         bytes32[] memory leaves = validatorContainer;
         for (uint256 i; i < MERKLE_TREE_HEIGHT; i++) {
             bytes32[] memory roots = new bytes32[](leaves.length / 2);

--- a/src/libraries/WithdrawalContainer.sol
+++ b/src/libraries/WithdrawalContainer.sol
@@ -39,7 +39,7 @@ library WithdrawalContainer {
         return withdrawalContainer[3].fromLittleEndianUint64();
     }
 
-    function merklelizeWithdrawalContainer(bytes32[] calldata withdrawalContainer) internal pure returns (bytes32) {
+    function merkleizeWithdrawalContainer(bytes32[] calldata withdrawalContainer) internal pure returns (bytes32) {
         bytes32[] memory leaves = withdrawalContainer;
         for (uint256 i; i < MERKLE_TREE_HEIGHT; i++) {
             bytes32[] memory roots = new bytes32[](leaves.length / 2);


### PR DESCRIPTION
There were some typos for `merkleize`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Corrected method names for better clarity and accuracy: `merkelizeValidatorContainer` and `merkleizeWithdrawalContainer`.

- **Bug Fixes**
	- Resolved spelling errors in function names to align with standard terminology related to Merkle trees.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->