### PR TITLE
feat: add associateOperator and dissociateOperator to support self-delegate

### DIFF
--- a/src/core/Bootstrap.sol
+++ b/src/core/Bootstrap.sol
@@ -12,7 +12,7 @@ import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import {OAppCoreUpgradeable} from "../lzApp/OAppCoreUpgradeable.sol";
 
 // This import is used for @inheritdoc but slither does not recognize it.
-// slither-disable-next-line unused-imports
+// slither-disable-next-line unused-import
 import {IBaseRestakingController} from "../interfaces/IBaseRestakingController.sol";
 import {ICustomProxyAdmin} from "../interfaces/ICustomProxyAdmin.sol";
 import {ILSTRestakingController} from "../interfaces/ILSTRestakingController.sol";

--- a/src/core/ExocoreGateway.sol
+++ b/src/core/ExocoreGateway.sol
@@ -208,14 +208,10 @@ contract ExocoreGateway is
         whenNotPaused
         isValidBech32Address(operator)
     {
-        if (!isRegisteredClientChain[clientChainId]) {
-            revert Errors.ExocoreGatewayNotRegisteredClientChainId();
-        }
-
         bytes memory staker = abi.encodePacked(bytes32(bytes20(msg.sender)));
         bool success = DELEGATION_CONTRACT.associateOperatorWithStaker(clientChainId, staker, bytes(operator));
         if (!success) {
-            revert AssociateOperatorFailed(clientChainId, msg.sender, operator);
+            revert Errors.AssociateOperatorFailed(clientChainId, msg.sender, operator);
         }
     }
 
@@ -225,14 +221,10 @@ contract ExocoreGateway is
      * @param clientChainId The id of client chain
      */
     function dissociateOperatorFromEVMStaker(uint32 clientChainId) external whenNotPaused {
-        if (!isRegisteredClientChain[clientChainId]) {
-            revert Errors.ExocoreGatewayNotRegisteredClientChainId();
-        }
-
         bytes memory staker = abi.encodePacked(bytes32(bytes20(msg.sender)));
         bool success = DELEGATION_CONTRACT.dissociateOperatorFromStaker(clientChainId, staker);
         if (!success) {
-            revert DissociateOperatorFailed(clientChainId, msg.sender);
+            revert Errors.DissociateOperatorFailed(clientChainId, msg.sender);
         }
     }
 

--- a/src/core/ExocoreGateway.sol
+++ b/src/core/ExocoreGateway.sol
@@ -555,7 +555,7 @@ contract ExocoreGateway is
         emit DelegateResult(result, bytes32(token), bytes32(depositor), string(operator), amount);
     }
 
-    /// @notice Hanldes the associating operator request, and no response would be returned.
+    /// @notice Handles the associating operator request, and no response would be returned.
     /// @dev Can only be called from this contract via low-level call.
     /// @param srcChainId The source chain id.
     /// @param lzNonce The layer zero nonce.

--- a/src/core/ExocoreGateway.sol
+++ b/src/core/ExocoreGateway.sol
@@ -579,7 +579,7 @@ contract ExocoreGateway is
         emit AssociateOperatorResult(result, bytes32(staker), operator);
     }
 
-    /// @notice Hanldes the dissociating operator request, and no response would be returned.
+    /// @notice Handles the dissociating operator request, and no response would be returned.
     /// @dev Can only be called from this contract via low-level call.
     /// @param srcChainId The source chain id.
     /// @param lzNonce The layer zero nonce.

--- a/src/interfaces/precompiles/IDelegation.sol
+++ b/src/interfaces/precompiles/IDelegation.sol
@@ -5,26 +5,26 @@ pragma solidity >=0.8.17;
 address constant DELEGATION_PRECOMPILE_ADDRESS = 0x0000000000000000000000000000000000000805;
 
 /// @dev The delegation contract's instance.
-IDelegation constant DELEGATION_CONTRACT = IDelegation(
-    DELEGATION_PRECOMPILE_ADDRESS
-);
+IDelegation constant DELEGATION_CONTRACT = IDelegation(DELEGATION_PRECOMPILE_ADDRESS);
 
 /// @author Exocore Team
 /// @title delegation Precompile Contract
 /// @dev The interface through which solidity contracts will interact with delegation
 /// @custom:address 0x0000000000000000000000000000000000000805
 interface IDelegation {
-/// TRANSACTIONS
-/// @dev delegate the client chain assets to the operator through client chain, that will change the states in delegation and assets module
-/// Note that this address cannot be a module account.
-/// @param clientChainID is the layerZero chainID if it is supported.
-//  It might be allocated by Exocore when the client chain isn't supported
-//  by layerZero
-/// @param lzNonce The cross chain tx layerZero nonce
-/// @param assetsAddress The client chain asset Address
-/// @param stakerAddress The staker address
-/// @param operatorAddr  The operator address that wants to be delegated to
-/// @param opAmount The delegation amount
+
+    /// TRANSACTIONS
+    /// @dev delegate the client chain assets to the operator through client chain, that will change the states in
+    /// delegation and assets module
+    /// Note that this address cannot be a module account.
+    /// @param clientChainID is the layerZero chainID if it is supported.
+    //  It might be allocated by Exocore when the client chain isn't supported
+    //  by layerZero
+    /// @param lzNonce The cross chain tx layerZero nonce
+    /// @param assetsAddress The client chain asset Address
+    /// @param stakerAddress The staker address
+    /// @param operatorAddr  The operator address that wants to be delegated to
+    /// @param opAmount The delegation amount
     function delegateToThroughClientChain(
         uint32 clientChainID,
         uint64 lzNonce,
@@ -34,17 +34,18 @@ interface IDelegation {
         uint256 opAmount
     ) external returns (bool success);
 
-/// TRANSACTIONS
-/// @dev undelegate the client chain assets from the operator through client chain, that will change the states in delegation and assets module
-/// Note that this address cannot be a module account.
-/// @param clientChainID is the layerZero chainID if it is supported.
-//  It might be allocated by Exocore when the client chain isn't supported
-//  by layerZero
-/// @param lzNonce The cross chain tx layerZero nonce
-/// @param assetsAddress The client chain asset Address
-/// @param stakerAddress The staker address
-/// @param operatorAddr  The operator address that wants to unDelegate from
-/// @param opAmount The Undelegation amount
+    /// TRANSACTIONS
+    /// @dev undelegate the client chain assets from the operator through client chain, that will change the states in
+    /// delegation and assets module
+    /// Note that this address cannot be a module account.
+    /// @param clientChainID is the layerZero chainID if it is supported.
+    //  It might be allocated by Exocore when the client chain isn't supported
+    //  by layerZero
+    /// @param lzNonce The cross chain tx layerZero nonce
+    /// @param assetsAddress The client chain asset Address
+    /// @param stakerAddress The staker address
+    /// @param operatorAddr  The operator address that wants to unDelegate from
+    /// @param opAmount The Undelegation amount
     function undelegateFromThroughClientChain(
         uint32 clientChainID,
         uint64 lzNonce,
@@ -54,28 +55,24 @@ interface IDelegation {
         uint256 opAmount
     ) external returns (bool success);
 
-/// TRANSACTIONS
-/// @dev associate the operator with staker so that we could count staker's delegation as self-delegate
-/// @notice a staker could only be associated with one operator while one operator could associate multiple stakers
-/// @param clientChainID is the layerZero chainID if it is supported.
-//  It might be allocated by Exocore when the client chain isn't supported
-//  by layerZero
-/// @param staker is the EVM address of the staker
-/// @param operator is the address that is to be marked as the owner.
-    function associateOperatorWithStaker(
-        uint32 clientChainID,
-        bytes memory staker,
-        bytes memory operator
-    ) external returns (bool success);
+    /// TRANSACTIONS
+    /// @dev associate the operator with staker so that we could count staker's delegation as self-delegate
+    /// @notice a staker could only be associated with one operator while one operator could associate multiple stakers
+    /// @param clientChainID is the layerZero chainID if it is supported.
+    //  It might be allocated by Exocore when the client chain isn't supported
+    //  by layerZero
+    /// @param staker is the EVM address of the staker
+    /// @param operator is the address that is to be marked as the owner.
+    function associateOperatorWithStaker(uint32 clientChainID, bytes memory staker, bytes memory operator)
+        external
+        returns (bool success);
 
-/// TRANSACTIONS
-/// @dev dissociate the operator that has already been associated with the staker
-/// @param clientChainID is the layerZero chainID if it is supported.
-//  It might be allocated by Exocore when the client chain isn't supported
-//  by layerZero
-/// @param staker is the EVM address to remove the marking from.
-    function dissociateOperatorFromStaker(
-        uint32 clientChainID,
-        bytes memory staker
-    ) external returns (bool success);
+    /// TRANSACTIONS
+    /// @dev dissociate the operator that has already been associated with the staker
+    /// @param clientChainID is the layerZero chainID if it is supported.
+    //  It might be allocated by Exocore when the client chain isn't supported
+    //  by layerZero
+    /// @param staker is the EVM address to remove the marking from.
+    function dissociateOperatorFromStaker(uint32 clientChainID, bytes memory staker) external returns (bool success);
+
 }

--- a/src/interfaces/precompiles/IDelegation.sol
+++ b/src/interfaces/precompiles/IDelegation.sol
@@ -5,26 +5,28 @@ pragma solidity >=0.8.17;
 address constant DELEGATION_PRECOMPILE_ADDRESS = 0x0000000000000000000000000000000000000805;
 
 /// @dev The delegation contract's instance.
-IDelegation constant DELEGATION_CONTRACT = IDelegation(DELEGATION_PRECOMPILE_ADDRESS);
+IDelegation constant DELEGATION_CONTRACT = IDelegation(
+    DELEGATION_PRECOMPILE_ADDRESS
+);
 
 /// @author Exocore Team
 /// @title delegation Precompile Contract
 /// @dev The interface through which solidity contracts will interact with delegation
 /// @custom:address 0x0000000000000000000000000000000000000805
 interface IDelegation {
-
-    /// TRANSACTIONS
-    /// @dev delegate the client chain assets to the operator through client chain, that will change the states in
-    /// delegation and assets module.
-    /// Note that this address cannot be a module account.
-    /// @param clientChainLzId The lzId of client chain
-    /// @param lzNonce The cross chain tx layerZero nonce
-    /// @param assetsAddress The client chain asset Address
-    /// @param stakerAddress The staker address
-    /// @param operatorAddr  The operator address that wants to be delegated to
-    /// @param opAmount The delegation amount
+/// TRANSACTIONS
+/// @dev delegate the client chain assets to the operator through client chain, that will change the states in delegation and assets module
+/// Note that this address cannot be a module account.
+/// @param clientChainID is the layerZero chainID if it is supported.
+//  It might be allocated by Exocore when the client chain isn't supported
+//  by layerZero
+/// @param lzNonce The cross chain tx layerZero nonce
+/// @param assetsAddress The client chain asset Address
+/// @param stakerAddress The staker address
+/// @param operatorAddr  The operator address that wants to be delegated to
+/// @param opAmount The delegation amount
     function delegateToThroughClientChain(
-        uint32 clientChainLzId,
+        uint32 clientChainID,
         uint64 lzNonce,
         bytes memory assetsAddress,
         bytes memory stakerAddress,
@@ -32,18 +34,19 @@ interface IDelegation {
         uint256 opAmount
     ) external returns (bool success);
 
-    /// TRANSACTIONS
-    /// @dev undelegate the client chain assets from the operator through client chain, that will change the states in
-    /// delegation and assets module
-    /// Note that this address cannot be a module account.
-    /// @param clientChainLzId The lzId of client chain
-    /// @param lzNonce The cross chain tx layerZero nonce
-    /// @param assetsAddress The client chain asset Address
-    /// @param stakerAddress The staker address
-    /// @param operatorAddr  The operator address that wants to unDelegate from
-    /// @param opAmount The Undelegation amount
+/// TRANSACTIONS
+/// @dev undelegate the client chain assets from the operator through client chain, that will change the states in delegation and assets module
+/// Note that this address cannot be a module account.
+/// @param clientChainID is the layerZero chainID if it is supported.
+//  It might be allocated by Exocore when the client chain isn't supported
+//  by layerZero
+/// @param lzNonce The cross chain tx layerZero nonce
+/// @param assetsAddress The client chain asset Address
+/// @param stakerAddress The staker address
+/// @param operatorAddr  The operator address that wants to unDelegate from
+/// @param opAmount The Undelegation amount
     function undelegateFromThroughClientChain(
-        uint32 clientChainLzId,
+        uint32 clientChainID,
         uint64 lzNonce,
         bytes memory assetsAddress,
         bytes memory stakerAddress,
@@ -51,4 +54,28 @@ interface IDelegation {
         uint256 opAmount
     ) external returns (bool success);
 
+/// TRANSACTIONS
+/// @dev associate the operator with staker so that we could count staker's delegation as self-delegate
+/// @notice a staker could only be associated with one operator while one operator could associate multiple stakers
+/// @param clientChainID is the layerZero chainID if it is supported.
+//  It might be allocated by Exocore when the client chain isn't supported
+//  by layerZero
+/// @param staker is the EVM address of the staker
+/// @param operator is the address that is to be marked as the owner.
+    function associateOperatorWithStaker(
+        uint32 clientChainID,
+        bytes memory staker,
+        bytes memory operator
+    ) external returns (bool success);
+
+/// TRANSACTIONS
+/// @dev dissociate the operator that has already been associated with the staker
+/// @param clientChainID is the layerZero chainID if it is supported.
+//  It might be allocated by Exocore when the client chain isn't supported
+//  by layerZero
+/// @param staker is the EVM address to remove the marking from.
+    function dissociateOperatorFromStaker(
+        uint32 clientChainID,
+        bytes memory staker
+    ) external returns (bool success);
 }

--- a/src/libraries/Errors.sol
+++ b/src/libraries/Errors.sol
@@ -165,6 +165,12 @@ library Errors {
     /// @dev ExocoreGateway: client chain should be registered before setting peer to change peer address
     error ExocoreGatewayNotRegisteredClientChainId();
 
+    /// @dev ExocoreGateway: thrown when associateOperatorWithEVMStaker failed
+    error AssociateOperatorFailed(uint32 clientChainId, address staker, string operator);
+
+    /// @dev thrown when dissociateOperatorFromEVMStaker failed
+    error DissociateOperatorFailed(uint32 clientChainId, address staker);
+
     ////////////////////////////////////////
     //  NativeRestakingController Errors  //
     ////////////////////////////////////////

--- a/src/storage/BootstrapStorage.sol
+++ b/src/storage/BootstrapStorage.sol
@@ -138,8 +138,6 @@ contract BootstrapStorage is GatewayStorage {
     /// this contract exceeding the limit and leading to creation failure.
     BeaconProxyBytecode public immutable BEACON_PROXY_BYTECODE;
 
-    bytes public constant EXO_ADDRESS_PREFIX = bytes("exo1");
-
     /* -------------------------------------------------------------------------- */
     /*                                   Events                                   */
     /* -------------------------------------------------------------------------- */
@@ -291,13 +289,6 @@ contract BootstrapStorage is GatewayStorage {
         _;
     }
 
-    /// @notice Ensures the provided address is a valid exo Bech32 encoded address.
-    /// @param addressToValidate The address to check.
-    modifier isValidBech32Address(string calldata addressToValidate) {
-        require(isValidExocoreAddress(addressToValidate), "BootstrapStorage: invalid bech32 encoded Exocore address");
-        _;
-    }
-
     /// @notice Initializes the contract with the given parameters.
     /// @param exocoreChainId_ The chain ID of the Exocore chain.
     /// @param vaultBeacon_ The address of the vault beacon.
@@ -326,25 +317,6 @@ contract BootstrapStorage is GatewayStorage {
             revert VaultNotExist();
         }
         return vault;
-    }
-
-    /// @notice Checks if the provided string is a valid Exocore address.
-    /// @param addressToValidate The string to check.
-    /// @return True if the string is valid, false otherwise.
-    /// @dev Since implementation of bech32 is difficult in Solidity, this function only
-    /// checks that the address is 42 characters long and starts with "exo1".
-    function isValidExocoreAddress(string calldata addressToValidate) public pure returns (bool) {
-        bytes memory stringBytes = bytes(addressToValidate);
-        if (stringBytes.length != 42) {
-            return false;
-        }
-        for (uint256 i = 0; i < EXO_ADDRESS_PREFIX.length; i++) {
-            if (stringBytes[i] != EXO_ADDRESS_PREFIX[i]) {
-                return false;
-            }
-        }
-
-        return true;
     }
 
     /// @notice Deploys a new vault for the given underlying token.

--- a/src/storage/ClientChainGatewayStorage.sol
+++ b/src/storage/ClientChainGatewayStorage.sol
@@ -28,9 +28,6 @@ contract ClientChainGatewayStorage is BootstrapStorage {
     /// @dev Mapping of request IDs to their corresponding request actions.
     mapping(uint64 => Action) internal _registeredRequestActions;
 
-    /// @dev Mapping of request IDs to their corresponding response hooks.
-    mapping(Action => bytes4) internal _registeredResponseHooks;
-
     /// @notice The address of the beacon chain oracle.
     address public immutable BEACON_ORACLE_ADDRESS;
 

--- a/src/storage/ExocoreGatewayStorage.sol
+++ b/src/storage/ExocoreGatewayStorage.sol
@@ -121,7 +121,16 @@ contract ExocoreGatewayStorage is GatewayStorage {
     event UndelegateResult(
         bool indexed success, bytes32 indexed token, bytes32 indexed undelegator, string operator, uint256 amount
     );
-    event AssociateOperatorResult(bool indexed success, bytes32 indexed staker, bytes32 indexed operator);
+
+    /// @notice Emitted upon handling associating operator request
+    /// @param success Whether the operation was successful.
+    /// @param staker The staker address that should be associated to @operator.
+    /// @param operator The operator address that @staker should be associated with.
+    event AssociateOperatorResult(bool indexed success, bytes32 indexed staker, bytes operator);
+
+    /// @notice Emitted upon handling dissociating operator request
+    /// @param success Whether the operation was successful.
+    /// @param staker The staker address that should be dissociated from @operator.
     event DissociateOperatorResult(bool indexed success, bytes32 indexed staker);
 
     /// @notice Thrown when the execution of a request fails
@@ -168,8 +177,12 @@ contract ExocoreGatewayStorage is GatewayStorage {
 
     /// @notice Thrown when the whitelist tokens list is too long.
     error WhitelistTokensListTooLong();
-    error AssociateOperatorFailed(uint32 clientChainId, string staker, string operator);
-    error DissociateOperatorFailed(uint32 clientChainId, string staker);
+
+    /// @notice Thrown when associateOperatorWithEVMStaker failed
+    error AssociateOperatorFailed(uint32 clientChainId, address staker, string operator);
+
+    /// @notice Thrown when dissociateOperatorFromEVMStaker failed
+    error DissociateOperatorFailed(uint32 clientChainId, address staker);
 
     /// @dev Storage gap to allow for future upgrades.
     uint256[40] private __gap;

--- a/src/storage/ExocoreGatewayStorage.sol
+++ b/src/storage/ExocoreGatewayStorage.sol
@@ -31,6 +31,10 @@ contract ExocoreGatewayStorage is GatewayStorage {
     /// @dev The length of a deposit-then-delegate request, in bytes.
     // bytes32 token + bytes32 delegator + bytes(42) operator + uint256 amount
     uint256 internal constant DEPOSIT_THEN_DELEGATE_REQUEST_LENGTH = DELEGATE_REQUEST_LENGTH;
+    // bytes32 staker + bytes(42) operator
+    uint256 internal constant ASSOCIATE_OPERATOR_REQUEST_LENGTH = 74;
+    // bytes32 staker
+    uint256 internal constant DISSOCIATE_OPERATOR_REQUEST_LENGTH = 32;
 
     // constants used for layerzero messaging
     /// @dev The gas limit for all the destination chains.
@@ -117,6 +121,8 @@ contract ExocoreGatewayStorage is GatewayStorage {
     event UndelegateResult(
         bool indexed success, bytes32 indexed token, bytes32 indexed undelegator, string operator, uint256 amount
     );
+    event AssociateOperatorResult(bool indexed success, bytes32 indexed staker, bytes32 indexed operator);
+    event DissociateOperatorResult(bool indexed success, bytes32 indexed staker);
 
     /// @notice Thrown when the execution of a request fails
     /// @param act The action that failed.
@@ -162,6 +168,8 @@ contract ExocoreGatewayStorage is GatewayStorage {
 
     /// @notice Thrown when the whitelist tokens list is too long.
     error WhitelistTokensListTooLong();
+    error AssociateOperatorFailed(uint32 clientChainId, string staker, string operator);
+    error DissociateOperatorFailed(uint32 clientChainId, string staker);
 
     /// @dev Storage gap to allow for future upgrades.
     uint256[40] private __gap;

--- a/src/storage/GatewayStorage.sol
+++ b/src/storage/GatewayStorage.sol
@@ -16,9 +16,14 @@ contract GatewayStorage {
         REQUEST_DEPOSIT_THEN_DELEGATE_TO,
         REQUEST_MARK_BOOTSTRAP,
         REQUEST_ADD_WHITELIST_TOKENS,
+        REQUEST_ASSOCIATE_OPERATOR,
+        REQUEST_DISSOCIATE_OPERATOR,
         RESPOND
     }
 
+    
+    bytes public constant EXO_ADDRESS_PREFIX = bytes("exo1");
+    
     /// @dev Mapping of actions to their corresponding function selectors.
     mapping(Action => bytes4) internal _whiteListFunctionSelectors;
 
@@ -47,6 +52,32 @@ contract GatewayStorage {
     /// @param expectedNonce The expected nonce.
     /// @param actualNonce The actual nonce received.
     error UnexpectedInboundNonce(uint64 expectedNonce, uint64 actualNonce);
+
+    /// @notice Ensures the provided address is a valid exo Bech32 encoded address.
+    /// @param addressToValidate The address to check.
+    modifier isValidBech32Address(string calldata addressToValidate) {
+        require(isValidExocoreAddress(addressToValidate), "BootstrapStorage: invalid bech32 encoded Exocore address");
+        _;
+    }
+
+    /// @notice Checks if the provided string is a valid Exocore address.
+    /// @param addressToValidate The string to check.
+    /// @return True if the string is valid, false otherwise.
+    /// @dev Since implementation of bech32 is difficult in Solidity, this function only
+    /// checks that the address is 42 characters long and starts with "exo1".
+    function isValidExocoreAddress(string calldata addressToValidate) public pure returns (bool) {
+        bytes memory stringBytes = bytes(addressToValidate);
+        if (stringBytes.length != 42) {
+            return false;
+        }
+        for (uint256 i = 0; i < EXO_ADDRESS_PREFIX.length; i++) {
+            if (stringBytes[i] != EXO_ADDRESS_PREFIX[i]) {
+                return false;
+            }
+        }
+
+        return true;
+    }
 
     /// @notice Verifies and updates the inbound nonce for a given source chain and address.
     /// @dev This function reverts if the nonce is not as expected.

--- a/src/storage/GatewayStorage.sol
+++ b/src/storage/GatewayStorage.sol
@@ -20,10 +20,10 @@ contract GatewayStorage {
         REQUEST_DISSOCIATE_OPERATOR,
         RESPOND
     }
+    /// @notice the human readable prefix for Exocore bech32 encoded address.
 
-    
     bytes public constant EXO_ADDRESS_PREFIX = bytes("exo1");
-    
+
     /// @dev Mapping of actions to their corresponding function selectors.
     mapping(Action => bytes4) internal _whiteListFunctionSelectors;
 

--- a/test/foundry/unit/ExocoreGateway.t.sol
+++ b/test/foundry/unit/ExocoreGateway.t.sol
@@ -851,7 +851,9 @@ contract AssociateOperatorWithEVMStaker is SetUp {
 
     function test_RevertWhen_ClientChainNotRegistered() public {
         Player memory staker = players[0];
-        vm.expectRevert(Errors.ExocoreGatewayNotRegisteredClientChainId.selector);
+        vm.expectRevert(
+            abi.encodeWithSelector(Errors.AssociateOperatorFailed.selector, anotherChainId, staker.addr, operator)
+        );
         vm.startPrank(staker.addr);
         exocoreGateway.associateOperatorWithEVMStaker(anotherChainId, operator);
     }
@@ -861,9 +863,7 @@ contract AssociateOperatorWithEVMStaker is SetUp {
 
         Player memory staker = players[0];
         vm.expectRevert(
-            abi.encodeWithSelector(
-                ExocoreGatewayStorage.AssociateOperatorFailed.selector, clientChainId, staker.addr, anotherOperator
-            )
+            abi.encodeWithSelector(Errors.AssociateOperatorFailed.selector, clientChainId, staker.addr, anotherOperator)
         );
         vm.startPrank(staker.addr);
         exocoreGateway.associateOperatorWithEVMStaker(clientChainId, anotherOperator);
@@ -912,16 +912,14 @@ contract AssociateOperatorWithEVMStaker is SetUp {
 
     function test_RevertWhen_DissociateClientChainNotRegistered() public {
         Player memory staker = players[0];
-        vm.expectRevert(Errors.ExocoreGatewayNotRegisteredClientChainId.selector);
+        vm.expectRevert(abi.encodeWithSelector(Errors.DissociateOperatorFailed.selector, anotherChainId, staker.addr));
         vm.startPrank(staker.addr);
         exocoreGateway.dissociateOperatorFromEVMStaker(anotherChainId);
     }
 
     function test_RevertWhen_DissociatePureStaker() public {
         Player memory staker = players[0];
-        vm.expectRevert(
-            abi.encodeWithSelector(ExocoreGatewayStorage.DissociateOperatorFailed.selector, clientChainId, staker.addr)
-        );
+        vm.expectRevert(abi.encodeWithSelector(Errors.DissociateOperatorFailed.selector, clientChainId, staker.addr));
         vm.startPrank(staker.addr);
         exocoreGateway.dissociateOperatorFromEVMStaker(clientChainId);
     }

--- a/test/mocks/AssetsMock.sol
+++ b/test/mocks/AssetsMock.sol
@@ -9,8 +9,8 @@ contract AssetsMock is IAssets {
     mapping(uint32 => mapping(bytes => mapping(bytes => uint256))) public principalBalances;
 
     uint32[] internal chainIds;
-    mapping(uint32 chainId => bool registered) isRegisteredChain;
-    mapping(uint32 chainId => mapping(bytes token => bool registered)) isRegisteredToken;
+    mapping(uint32 chainId => bool registered) public isRegisteredChain;
+    mapping(uint32 chainId => mapping(bytes token => bool registered)) public isRegisteredToken;
 
     function depositTo(uint32 clientChainLzId, bytes memory assetsAddress, bytes memory stakerAddress, uint256 opAmount)
         external

--- a/test/mocks/DelegationMock.sol
+++ b/test/mocks/DelegationMock.sol
@@ -5,6 +5,7 @@ import {IDelegation} from "../../src/interfaces/precompiles/IDelegation.sol";
 contract DelegationMock is IDelegation {
 
     mapping(bytes => mapping(bytes => mapping(uint32 => mapping(bytes => uint256)))) public delegateTo;
+    mapping(uint32 clientChainId => mapping(bytes staker => bytes operator)) public stakerToOperator;
 
     event DelegateRequestProcessed(
         uint32 clientChainLzId,
@@ -60,6 +61,16 @@ contract DelegationMock is IDelegation {
         );
 
         return true;
+    }
+
+    function associateOperatorWithStaker(uint32 clientChainId, bytes memory staker, bytes memory operator) external returns (bool success) {
+        stakerToOperator[clientChainId][staker] = operator;
+    }
+
+    function dissociateOperatorFromStaker(uint32 clientChainId, bytes memory staker) external returns (bool success) {
+        require(stakerToOperator[clientChainId][staker].length != 0, "staker has not been associated with any operator");
+
+        delete stakerToOperator[clientChainId][staker];
     }
 
     function getDelegateAmount(address delegator, string memory operator, uint32 clientChainLzId, address token)

--- a/test/mocks/DelegationMock.sol
+++ b/test/mocks/DelegationMock.sol
@@ -1,11 +1,14 @@
 pragma solidity ^0.8.19;
 
+import {ASSETS_PRECOMPILE_ADDRESS, IAssets} from "../../src/interfaces/precompiles/IAssets.sol";
 import {IDelegation} from "../../src/interfaces/precompiles/IDelegation.sol";
+import {AssetsMock} from "./AssetsMock.sol";
 
 contract DelegationMock is IDelegation {
 
     mapping(bytes => mapping(bytes => mapping(uint32 => mapping(bytes => uint256)))) public delegateTo;
     mapping(uint32 clientChainId => mapping(bytes staker => bytes operator)) public stakerToOperator;
+    mapping(uint32 chainId => bool registered) isRegisteredChain;
 
     event DelegateRequestProcessed(
         uint32 clientChainLzId,
@@ -32,6 +35,9 @@ contract DelegationMock is IDelegation {
         bytes memory operatorAddr,
         uint256 opAmount
     ) external returns (bool success) {
+        if (!AssetsMock(ASSETS_PRECOMPILE_ADDRESS).isRegisteredChain(clientChainLzId)) {
+            return false;
+        }
         if (operatorAddr.length != 42) {
             return false;
         }
@@ -51,6 +57,9 @@ contract DelegationMock is IDelegation {
         bytes memory operatorAddr,
         uint256 opAmount
     ) external returns (bool success) {
+        if (!AssetsMock(ASSETS_PRECOMPILE_ADDRESS).isRegisteredChain(clientChainLzId)) {
+            return false;
+        }
         if (operatorAddr.length != 42) {
             return false;
         }
@@ -69,6 +78,9 @@ contract DelegationMock is IDelegation {
         external
         returns (bool success)
     {
+        if (!AssetsMock(ASSETS_PRECOMPILE_ADDRESS).isRegisteredChain(clientChainId)) {
+            return false;
+        }
         if (stakerToOperator[clientChainId][staker].length > 0) {
             return false;
         }
@@ -78,6 +90,9 @@ contract DelegationMock is IDelegation {
     }
 
     function dissociateOperatorFromStaker(uint32 clientChainId, bytes memory staker) external returns (bool success) {
+        if (!AssetsMock(ASSETS_PRECOMPILE_ADDRESS).isRegisteredChain(clientChainId)) {
+            return false;
+        }
         if (stakerToOperator[clientChainId][staker].length == 0) {
             return false;
         }


### PR DESCRIPTION
## Description

This PR would collaborate with https://github.com/ExocoreNetwork/exocore/pull/125 to make self-delegate possible. As Chuang's [design doc](https://www.notion.so/exocore/Marking-self-delegation-and-the-staking-compatibility-for-the-other-non-EVM-client-chains-48cfa40ec5eb41b0a2a484c1bda0f65b) presents, there are generally three types of client chains regarding self-delegate process:

1. the client chains that are EVM-compatible
2. the client chains that have other types of VMs and could be bridged to Exocore
3. the client chains that have no VM

For type 1 client chains, to associate an EVM address with an operator address is simple: the authority that holds the key for the EVM address could always send an EVM transaction to Exocore and call `ExocoreGateway.associateOpratorWithEVMStaker`, since the EVM address should remain the same for the same private key no matter which EVM-compatible chain the transaction is sent to. 
```solidity
function associateOperatorWithEVMStaker(uint32 clientChainId, string calldata operator)
        external
        whenNotPaused
        isValidBech32Address(operator)
    {}

function dissociateOperatorFromEVMStaker(uint32 clientChainId) external whenNotPaused {
}
```

Things get more difficult for type 2 client chains: even for the same private key, owing to different cryptographic schemes, the address could be different for EVM and other VM, and we can't link these two addresses without knowing the private key. So in this case, staker should initiate the request from client chain and send the request to Exocore via bridge, so that we could link a Non-EVM address with an operator address.
```solidity
function requestAssociateOperatorWithStaker(uint32 srcChainId, uint64 lzNonce, bytes calldata payload)
        public
        onlyCalledFromThis
{
}

function requestDissociateOperatorFromStaker(uint32 srcChainId, uint64 lzNonce, bytes calldata payload)
        public
        onlyCalledFromThis
    {
}
```

It is most difficult for type 3 client chains, where we have to recover staker's address from its signature in Exocore's contracts and then link that address with some operator address. We would leave this for future implementation as it brings many complexities.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Added functionality to associate and dissociate operators with EVM stakers.
	- Introduced events for successful operator association and dissociation.
	- Enhanced the `IDelegation` interface with new functions for operator-staker management.
	- Added new mappings and functions in mock contracts for better testing of operator-staker relationships.

- **Bug Fixes**
	- Corrected comment directive for unused imports to align with static analysis tools.

- **Chores**
	- Removed outdated address validation logic to simplify contract functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->