### PR TITLE
refacotr: remove unused fields for `ExoCapsuleStorage.Validator`

### DIFF
--- a/src/storage/ExoCapsuleStorage.sol
+++ b/src/storage/ExoCapsuleStorage.sol
@@ -27,10 +27,6 @@ contract ExoCapsuleStorage {
     struct Validator {
         // index of the validator in the beacon chain
         uint256 validatorIndex;
-        // amount of beacon chain ETH restaked on Exocore in gwei
-        uint64 restakedBalanceGwei;
-        //timestamp of the validator's most recent balance update
-        uint256 mostRecentBalanceUpdateTimestamp;
         // status of the validator
         VALIDATOR_STATUS status;
     }

--- a/test/foundry/unit/ExoCapsule.t.sol
+++ b/test/foundry/unit/ExoCapsule.t.sol
@@ -139,8 +139,6 @@ contract VerifyDepositProof is DepositSetup {
             capsule.getRegisteredValidatorByPubkey(_getPubkey(validatorContainer));
         assertEq(uint8(validator.status), uint8(ExoCapsuleStorage.VALIDATOR_STATUS.REGISTERED));
         assertEq(validator.validatorIndex, validatorProof.validatorIndex);
-        assertEq(validator.mostRecentBalanceUpdateTimestamp, validatorProof.beaconBlockTimestamp);
-        assertEq(validator.restakedBalanceGwei, _getEffectiveBalance(validatorContainer));
     }
 
     function test_verifyDepositProof_revert_validatorAlreadyDeposited() public {
@@ -377,8 +375,6 @@ contract WithdrawalSetup is Test {
             capsule.getRegisteredValidatorByPubkey(_getPubkey(validatorContainer));
         assertEq(uint8(validator.status), uint8(ExoCapsuleStorage.VALIDATOR_STATUS.REGISTERED));
         assertEq(validator.validatorIndex, validatorProof.validatorIndex);
-        assertEq(validator.mostRecentBalanceUpdateTimestamp, validatorProof.beaconBlockTimestamp);
-        assertEq(validator.restakedBalanceGwei, depositAmount / 1e9);
 
         vm.deal(address(capsule), 1 ether); // Deposit 1 ether to handle excess amount withdraw
     }


### PR DESCRIPTION
## Description

For `ExoCapsuleStorage.Validator`:
https://github.com/ExocoreNetwork/exocore-contracts/blob/4cb7879aeda66d079c43f9b9ebf036261a2bad23/src/storage/ExoCapsuleStorage.sol#L27-L36

some fields like `restakedBalanceGwei` and `mostRecentBalanceUpdateTimestamp` are not used in ExoCapsule, and regarding their intended usage, we could safely remove them since not needed:

1. `mostRecentBalanceUpdateTimestamp` is intended to be used for updating validator balance: we check the proof timestamp against this value to make sure that the a newer price is always updated, but as we would update the total balance of capsule by Exocore oracle and the oracle would update this balance in a fixed interval, we could safely remove this field
2. `restakedBalanceGwei` is used for recording the balance of validator: while we have `principalBalance` and `withdrawableBalance` for tracking the total balance of capsule and the total balance of capsule is counted in Exocore chain as single source of truth, we could safely remove this field


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Simplified proof validation logic for improved performance.
	- Enhanced clarity in validator state management by refining data structures.
  
- **Bug Fixes**
	- Streamlined testing processes by removing unnecessary assertions related to validator timestamps and balances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->