### PR TITLE
chore: fix solc compiler warnigs

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -6,6 +6,10 @@ fs_permissions = [{ access = "read-write", path = "./"}]
 gas_limit = "18446744073709551615"
 memory_limit = 18446744073709
 evm_version = "paris"
+# ignore compiler warning: unused-param
+ignored_error_codes = [5667]
+# ignore warnings from script folder and test folder
+ignored_warnings_from = ["script", "test"]
 
 [rpc_endpoints]
 ethereum_local_rpc = "${ETHEREUM_LOCAL_RPC}"

--- a/src/core/ClientChainGateway.sol
+++ b/src/core/ClientChainGateway.sol
@@ -109,7 +109,7 @@ contract ClientChainGateway is
 
     /// @notice Gets the count of whitelisted tokens.
     /// @return The count of whitelisted tokens.
-    function getWhitelistedTokensCount() external returns (uint256) {
+    function getWhitelistedTokensCount() external view returns (uint256) {
         return whitelistTokens.length;
     }
 

--- a/src/core/ClientGatewayLzReceiver.sol
+++ b/src/core/ClientGatewayLzReceiver.sol
@@ -139,7 +139,11 @@ abstract contract ClientGatewayLzReceiver is PausableUpgradeable, OAppReceiverUp
     /// @return RequestId for the response
     /// @return The action for the response
     /// @return The cached request for the response
-    function _getCachedRequestForResponse(bytes calldata response) internal returns (uint64, Action, bytes memory) {
+    function _getCachedRequestForResponse(bytes calldata response)
+        internal
+        view
+        returns (uint64, Action, bytes memory)
+    {
         uint64 requestId = uint64(bytes8(response[1:9]));
 
         bytes memory cachedRequest = _registeredRequests[requestId];

--- a/src/libraries/BeaconChainProofs.sol
+++ b/src/libraries/BeaconChainProofs.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import {Endian} from "../libraries/Endian.sol";

--- a/src/libraries/Endian.sol
+++ b/src/libraries/Endian.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 library Endian {

--- a/src/libraries/Errors.sol
+++ b/src/libraries/Errors.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.19;
 
 /// @dev @title Errors library

--- a/src/libraries/Merkle.sol
+++ b/src/libraries/Merkle.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 // Adapted from OpenZeppelin Contracts (last updated v4.8.0) (utils/cryptography/MerkleProof.sol)
 pragma solidity ^0.8.0;
 

--- a/src/libraries/ValidatorContainer.sol
+++ b/src/libraries/ValidatorContainer.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.19;
 
 import {Endian} from "../libraries/Endian.sol";

--- a/src/libraries/WithdrawalContainer.sol
+++ b/src/libraries/WithdrawalContainer.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.19;
 
 import {Endian} from "../libraries/Endian.sol";


### PR DESCRIPTION
## Description

There are some warnings by solc compiler when we run `forge build`, which include unused function params, function mutability, and other warnings from script directory or test directory.

we fix these warnings by:

1. config foundry.toml to ignore warnings from script directory or test directory
2. config foundry.toml to ignore unused-params
3. change function visibility to view for suggested functions

after these changes, now when we run `forge build`:
```bash
exocore-contracts % forge build --force
[⠊] Compiling...
[⠒] Compiling 174 files with Solc 0.8.24
[⠃] Solc 0.8.24 finished in 29.68s
Compiler run successful!
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced configuration options to ignore specific compiler warnings and error codes.
	- Improved clarity on function usage with updated function signatures for better efficiency.

- **Documentation**
	- Added SPDX license identifiers to multiple files for clarity on licensing terms.

- **Bug Fixes**
	- Updated function signatures to ensure they are correctly marked as view, enhancing the understanding of their non-modifying behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->