### PR TITLE
refactor(precompiles): chain as source of truth

### DIFF
--- a/docs/contracts-owner-manual.md
+++ b/docs/contracts-owner-manual.md
@@ -17,12 +17,10 @@ While for `Vault` and `ExoCapsule`, they are deployed with upgradeable beacon pr
 
 After all contracts are deployed, before the protocol starts to work, there are a few works left to be done by contract owner to enable restaking. One of the most important tasks is to register the client chain id and meta info to Exocore to mark this client chain as valid. This is done by the contract caller calling `ExocoreGateway.registerOrUpdateClientChain` to write `clientChainId`, `addressLength`, `name`, `signatureType` and other meta data to Exocore native module to finish registration. This operation would also call `ExocoreGateway.setPeer` to enable LayerZero messaging by setting remote `ClientChainGateway` as trusted peer to send/receive messages. After finishing registration, contract owner could call `ExocoreGateway.registerOrUpdateClientChain` again to update the meta data and set new peer, or contract owner could solely call `ExocoreGateway.setPeer` to change the address of remote peer contract.
 
-## add tokens to whitelist
+## add or update tokens to whitelist
 
-Another important task before restaking being activated is to add tokens to whitelist to mark them as stake-able on both Exocore and client chain. This is done by contract owner calling `ExocoreGateway.addWhitelistTokens` to write token addresses, decimals, TVL limits and other metadata to Exocore, as well as sending a cross-chain message through layerzero to client chain to add these token addresses to the whitelist of `ClientChainGateway`. 
+Another important task before restaking being activated is to add tokens to whitelist to mark them as stake-able on both Exocore and client chain. This is done by contract owner calling `ExocoreGateway.addOrUpdateWhitelistTokens` to write token addresses, decimals, TVL limits and other metadata to Exocore, as well as sending a cross-chain message through layerzero to client chain to add these token addresses to the whitelist of `ClientChainGateway`. 
 
 Notice: contract owner must make sure the token data is correct like address, decimals and TVL limit, more importantly contract owner must ensure that for the same index, the data in different arrays like `tokens`, `decimals`, `tvlLimits` must point to the same token to be composed as complete token data.
 
-## upgrade the meta data of whitelisted tokens 
-
-After adding tokens to whitelist, contract owner could call `ExocoreGateway.updateWhitelistedTokens` to update the meta data of already whitelisted tokens, and this function would not send a cross-chain message to client chain since the whitelist of `ClientChainGateway` only stores the token addresses.
+After adding tokens to whitelist, contract owner could call `ExocoreGateway.addOrUpdateWhitelistTokens` to update the meta data of already whitelisted tokens, and this function would not send a cross-chain message to client chain since the whitelist of `ClientChainGateway` only stores the token addresses.

--- a/script/3_Setup.s.sol
+++ b/script/3_Setup.s.sol
@@ -118,7 +118,7 @@ contract SetupScript is BaseScript {
         vm.selectFork(exocore);
         uint256 messageLength = TOKEN_ADDRESS_BYTES_LENGTH * whitelistTokensBytes32.length + 2;
         uint256 nativeFee = exocoreGateway.quote(clientChainId, new bytes(messageLength));
-        exocoreGateway.addWhitelistTokens{value: nativeFee}(
+        exocoreGateway.addOrUpdateWhitelistTokens{value: nativeFee}(
             clientChainId, whitelistTokensBytes32, decimals, tvlLimits, names, metaData
         );
         vm.stopBroadcast();

--- a/src/core/ExocoreGateway.sol
+++ b/src/core/ExocoreGateway.sol
@@ -155,7 +155,8 @@ contract ExocoreGateway is
     }
 
     /// @notice Sets a peer on the destination chain for this contract.
-    /// @dev This is the LayerZero peer. This function is only here for the modifiers.
+    /// @dev This is the LayerZero peer. This function is here for the modifiers
+    ///      as well as checking the registration of the client chain id.
     /// @param clientChainId The id of the client chain.
     /// @param clientChainGateway The address of the peer as bytes32.
     function setPeer(uint32 clientChainId, bytes32 clientChainGateway)
@@ -164,9 +165,10 @@ contract ExocoreGateway is
         onlyOwner
         whenNotPaused
     {
-        // The registration of the client chain is done here and nowhere else.
-        // Elsewhere, the precompile is responsible for the checks. The precompile
-        // is not called here at all, and hence, such a check must be made manually.
+        // This check, for the registration of the client chain id, is done here and
+        // nowhere else. Elsewhere, the precompile is responsible for the checks.
+        // The precompile is not called here at all, and hence, such a check must be
+        // performed manually.
         _validateClientChainIdRegistered(clientChainId);
         super.setPeer(clientChainId, clientChainGateway);
     }
@@ -285,6 +287,8 @@ contract ExocoreGateway is
     ///      checks.
     /// @param clientChainId The client chain id.
     function _validateClientChainIdRegistered(uint32 clientChainId) internal view {
+        // TODO: check if this read-only call has the same problem as the
+        // getClientChains call, which is also read-only.
         (bool success, bool isRegistered) = ASSETS_CONTRACT.isRegisteredClientChain(clientChainId);
         if (!success) {
             revert Errors.ExocoreGatewayFailedToCheckClientChainId();

--- a/src/core/ExocoreGateway.sol
+++ b/src/core/ExocoreGateway.sol
@@ -186,7 +186,7 @@ contract ExocoreGateway is
             require(bytes(names[i]).length != 0, "ExocoreGateway: name cannot be empty");
             require(bytes(metaData[i]).length != 0, "ExocoreGateway: meta data cannot be empty");
 
-            (success, updated) = ASSETS_CONTRACT.registerOrUpdateToken(
+            (success, updated) = ASSETS_CONTRACT.registerOrUpdateTokens(
                 clientChainId, abi.encodePacked(tokens[i]), decimals[i], tvlLimits[i], names[i], metaData[i]
             );
 

--- a/src/interfaces/IExocoreGateway.sol
+++ b/src/interfaces/IExocoreGateway.sol
@@ -49,7 +49,7 @@ interface IExocoreGateway is IOAppReceiver, IOAppCore {
     /// @param names The names of the tokens, in the same order as the tokens list.
     /// @param metaData The meta information of the tokens, in the same order as the tokens list.
     /// @dev The chain must be registered before adding tokens.
-    function addWhitelistTokens(
+    function addOrUpdateWhitelistTokens(
         uint32 clientChainId,
         bytes32[] calldata tokens,
         uint8[] calldata decimals,
@@ -57,22 +57,5 @@ interface IExocoreGateway is IOAppReceiver, IOAppCore {
         string[] calldata names,
         string[] calldata metaData
     ) external payable;
-
-    /// @notice Updates a list of whitelisted tokens to the client chain.
-    /// @param clientChainId The LayerZero chain id of the client chain.
-    /// @param tokens The list of token addresses to be whitelisted.
-    /// @param decimals The list of token decimals, in the same order as the tokens list.
-    /// @param tvlLimits The list of token TVL limits (typically max supply),in the same order as the tokens list.
-    /// @param names The names of the tokens, in the same order as the tokens list.
-    /// @param metaData The meta information of the tokens, in the same order as the tokens list.
-    /// @dev The chain must be registered before updating tokens, and the token as well.
-    function updateWhitelistedTokens(
-        uint32 clientChainId,
-        bytes32[] calldata tokens,
-        uint8[] calldata decimals,
-        uint256[] calldata tvlLimits,
-        string[] calldata names,
-        string[] calldata metaData
-    ) external;
 
 }

--- a/src/interfaces/precompiles/IAssets.sol
+++ b/src/interfaces/precompiles/IAssets.sol
@@ -80,4 +80,10 @@ interface IAssets {
     /// @dev Returns the chain indices of the client chains.
     function getClientChains() external view returns (bool, uint32[] memory);
 
+    /// @dev Checks if the client chain is registered, given the chain ID.
+    /// @param clientChainID is the layerZero chainID if it is supported.
+    /// @return success true if the query is successful
+    /// @return isRegistered true if the client chain is registered
+    function isRegisteredClientChain(uint32 clientChainID) external view returns (bool success, bool isRegistered);
+
 }

--- a/src/interfaces/precompiles/IAssets.sol
+++ b/src/interfaces/precompiles/IAssets.sol
@@ -67,7 +67,7 @@ interface IAssets {
     /// @param metaData is the arbitrary metadata of the token
     /// @return success if the token registration is successful
     /// @return updated whether the token was added or updated
-    function registerOrUpdateToken(
+    function registerOrUpdateTokens(
         uint32 clientChainID,
         bytes calldata token,
         uint8 decimals,

--- a/src/interfaces/precompiles/IAssets.sol
+++ b/src/interfaces/precompiles/IAssets.sol
@@ -17,59 +17,67 @@ interface IAssets {
     /// @dev deposit the client chain assets for the staker,
     /// that will change the state in deposit module
     /// Note that this address cannot be a module account.
-    /// @param clientChainLzID The LzID of client chain
+    /// @param clientChainID is the layerZero chainID if it is supported.
+    //  It might be allocated by Exocore when the client chain isn't supported
+    //  by layerZero
     /// @param assetsAddress The client chain asset address
     /// @param stakerAddress The staker address
     /// @param opAmount The amount to deposit
-    function depositTo(uint32 clientChainLzID, bytes memory assetsAddress, bytes memory stakerAddress, uint256 opAmount)
+    function depositTo(uint32 clientChainID, bytes memory assetsAddress, bytes memory stakerAddress, uint256 opAmount)
         external
         returns (bool success, uint256 latestAssetState);
 
-    /// TRANSACTIONS
     /// @dev withdraw To the staker, that will change the state in withdraw module
     /// Note that this address cannot be a module account.
-    /// @param clientChainLzID The LzID of client chain
+    /// @param clientChainID is the layerZero chainID if it is supported.
+    //  It might be allocated by Exocore when the client chain isn't supported
+    //  by layerZero
     /// @param assetsAddress The client chain asset Address
     /// @param withdrawAddress The withdraw address
     /// @param opAmount The withdraw amount
     function withdrawPrincipal(
-        uint32 clientChainLzID,
+        uint32 clientChainID,
         bytes memory assetsAddress,
         bytes memory withdrawAddress,
         uint256 opAmount
     ) external returns (bool success, uint256 latestAssetState);
 
-    /// QUERIES
-    /// @dev Returns the chain indices of the client chains.
-    function getClientChains() external view returns (bool, uint32[] memory);
-
-    /// TRANSACTIONS
-    /// @dev register some client chain to allow token registration from that chain, staking
-    /// from that chain, and other operations from that chain.
+    /// @dev registers or updates a client chain to allow deposits / staking, etc.
+    /// from that chain.
     /// @param clientChainID is the layerZero chainID if it is supported.
     //  It might be allocated by Exocore when the client chain isn't supported
     //  by layerZero
-    function registerClientChain(
+    function registerOrUpdateClientChain(
         uint32 clientChainID,
         uint8 addressLength,
         string calldata name,
         string calldata metaInfo,
         string calldata signatureType
-    ) external returns (bool success);
+    ) external returns (bool success, bool updated);
 
-    /// TRANSACTIONS
-    /// @dev register unwhitelisted token address to exocore assets module
-    /// @param clientChainID is the layerZero chainID if it is supported.
-    //  It might be allocated by Exocore when the client chain isn't supported
-    //  by layerZero
-    /// @param token The token address that would be registered to exocore
-    function registerToken(
+    /// @dev register or update token addresses to exocore
+    /// @dev note that there is no way to delete a token. If a token is to be removed,
+    /// the TVL limit should be set to 0.
+    /// @param clientChainID is the identifier of the token's home chain (LZ or otherwise)
+    /// @param token is the address of the token on the home chain
+    /// @param decimals is the number of decimals of the token
+    /// @param tvlLimit is the number of tokens that can be deposited in the system. Set to
+    /// maxSupply if there is no limit
+    /// @param name is the name of the token
+    /// @param metaData is the arbitrary metadata of the token
+    /// @return success if the token registration is successful
+    /// @return updated whether the token was added or updated
+    function registerOrUpdateToken(
         uint32 clientChainID,
         bytes calldata token,
         uint8 decimals,
         uint256 tvlLimit,
         string calldata name,
         string calldata metaData
-    ) external returns (bool success);
+    ) external returns (bool success, bool updated);
+
+    /// QUERIES
+    /// @dev Returns the chain indices of the client chains.
+    function getClientChains() external view returns (bool, uint32[] memory);
 
 }

--- a/src/libraries/Errors.sol
+++ b/src/libraries/Errors.sol
@@ -163,9 +163,6 @@ library Errors {
     /// @dev ExocoreGateway: failed to decode client chain ids
     error ExocoreGatewayFailedToDecodeClientChainIds();
 
-    /// @dev ExocoreGateway: client chain should be registered before setting peer to change peer address
-    error ExocoreGatewayNotRegisteredClientChainId();
-
     /// @dev ExocoreGateway: thrown when associateOperatorWithEVMStaker failed
     error AssociateOperatorFailed(uint32 clientChainId, address staker, string operator);
 

--- a/src/libraries/Errors.sol
+++ b/src/libraries/Errors.sol
@@ -163,6 +163,12 @@ library Errors {
     /// @dev ExocoreGateway: failed to decode client chain ids
     error ExocoreGatewayFailedToDecodeClientChainIds();
 
+    /// @dev ExocoreGateway: client chain should be registered before.
+    error ExocoreGatewayNotRegisteredClientChainId();
+
+    /// @dev ExocoreGateway: failed to check if the client id is registered
+    error ExocoreGatewayFailedToCheckClientChainId();
+
     /// @dev ExocoreGateway: thrown when associateOperatorWithEVMStaker failed
     error AssociateOperatorFailed(uint32 clientChainId, address staker, string operator);
 

--- a/src/libraries/Errors.sol
+++ b/src/libraries/Errors.sol
@@ -160,9 +160,6 @@ library Errors {
     /// @dev ExocoreGateway: failed to get client chain ids
     error ExocoreGatewayFailedToGetClientChainIds();
 
-    /// @dev ExocoreGateway: failed to decode client chain ids
-    error ExocoreGatewayFailedToDecodeClientChainIds();
-
     /// @dev ExocoreGateway: client chain should be registered before.
     error ExocoreGatewayNotRegisteredClientChainId();
 

--- a/src/storage/ExocoreGatewayStorage.sol
+++ b/src/storage/ExocoreGatewayStorage.sol
@@ -47,14 +47,6 @@ contract ExocoreGatewayStorage is GatewayStorage {
     /// @dev Used to ensure no repeated bootstrap requests are sent.
     mapping(uint32 clienChainId => bool) public chainToBootstrapped;
 
-    /// @notice A mapping from client chain IDs to whether the chain has been registered.
-    /// @dev Used to ensure that only registered client chains can interact with the gateway.
-    mapping(uint32 clienChainId => bool registered) public isRegisteredClientChain;
-
-    /// @notice A mapping from token address to whether the token is whitelisted.
-    /// @dev Used to ensure no duplicate tokens are added to the whitelist.
-    mapping(bytes32 token => bool whitelisted) public isWhitelistedToken;
-
     /// @notice Emitted when a precompile call fails.
     /// @param precompile Address of the precompile contract.
     /// @param nonce The LayerZero nonce
@@ -170,10 +162,6 @@ contract ExocoreGatewayStorage is GatewayStorage {
 
     /// @notice Thrown when the whitelist tokens input is invalid.
     error InvalidWhitelistTokensInput();
-
-    /// @notice Thrown when the client chain ID is not registered.
-    /// @param clientChainId The LayerZero chain ID of the client chain.
-    error ClientChainIDNotRegisteredBefore(uint32 clientChainId);
 
     /// @notice Thrown when the whitelist tokens list is too long.
     error WhitelistTokensListTooLong();

--- a/src/storage/ExocoreGatewayStorage.sol
+++ b/src/storage/ExocoreGatewayStorage.sol
@@ -125,6 +125,10 @@ contract ExocoreGatewayStorage is GatewayStorage {
     /// @param staker The staker address that should be dissociated from @operator.
     event DissociateOperatorResult(bool indexed success, bytes32 indexed staker);
 
+    /// @notice Emitted when a REQUEST_MARK_BOOTSTRAP is sent to @param clientChainId.
+    /// @param clientChainId The LayerZero chain ID of chain to which it is destined.
+    event BootstrapRequestSent(uint32 clientChainId);
+
     /// @notice Thrown when the execution of a request fails
     /// @param act The action that failed.
     /// @param nonce The LayerZero nonce.

--- a/test/foundry/ExocoreDeployer.t.sol
+++ b/test/foundry/ExocoreDeployer.t.sol
@@ -183,7 +183,7 @@ contract ExocoreDeployer is Test {
             uint64(1),
             registerTokensRequestNativeFee
         );
-        exocoreGateway.addWhitelistTokens{value: registerTokensRequestNativeFee}(
+        exocoreGateway.addOrUpdateWhitelistTokens{value: registerTokensRequestNativeFee}(
             clientChainId, whitelistTokens, decimals, tvlLimits, names, metaData
         );
 

--- a/test/foundry/unit/ExoCapsule.t.sol
+++ b/test/foundry/unit/ExoCapsule.t.sol
@@ -241,8 +241,6 @@ contract VerifyDepositProof is DepositSetup {
             capsule.getRegisteredValidatorByPubkey(_getPubkey(validatorContainer));
         assertEq(uint8(validator.status), uint8(ExoCapsuleStorage.VALIDATOR_STATUS.REGISTERED));
         assertEq(validator.validatorIndex, validatorProof.validatorIndex);
-        assertEq(validator.mostRecentBalanceUpdateTimestamp, validatorProof.beaconBlockTimestamp);
-        assertEq(validator.restakedBalanceGwei, _getEffectiveBalance(validatorContainer));
     }
 
     function test_verifyDepositProof_revert_mismatchWithdrawalCredentials() public {

--- a/test/foundry/unit/ExocoreGateway.t.sol
+++ b/test/foundry/unit/ExocoreGateway.t.sol
@@ -501,6 +501,12 @@ contract SetPeer is SetUp {
         exocoreGateway.setPeer(anotherClientChain, newPeer);
     }
 
+    function test_RevertWhen_ClientChainNotRegistered() public {
+        vm.startPrank(exocoreValidatorSet.addr);
+        vm.expectRevert(Errors.ExocoreGatewayNotRegisteredClientChainId.selector);
+        exocoreGateway.setPeer(anotherClientChain, newPeer);
+    }
+
 }
 
 contract AddWhitelistTokens is SetUp {

--- a/test/foundry/unit/ExocoreGateway.t.sol
+++ b/test/foundry/unit/ExocoreGateway.t.sol
@@ -903,10 +903,10 @@ contract MarkBootstrap is SetUp {
     function test_Success_Multiple() public {
         _registerClientChain();
         vm.startPrank(exocoreValidatorSet.addr);
-        // vm.expectEmit(address(exocoreGateway));
-        // emit ExocoreGatewayStorage.BootstrapRequestSent(clientChainId);
-        // vm.expectEmit(address(exocoreGateway));
-        // emit ExocoreGatewayStorage.BootstrapRequestSent(anotherClientChainId);
+        vm.expectEmit(address(exocoreGateway));
+        emit ExocoreGatewayStorage.BootstrapRequestSent(clientChainId);
+        vm.expectEmit(address(exocoreGateway));
+        emit ExocoreGatewayStorage.BootstrapRequestSent(anotherClientChainId);
         assertEq(exocoreGateway.chainToBootstrapped(clientChainId), false);
         assertEq(exocoreGateway.chainToBootstrapped(anotherClientChainId), false);
         exocoreGateway.markBootstrapOnAllChains();

--- a/test/foundry/unit/ExocoreGateway.t.sol
+++ b/test/foundry/unit/ExocoreGateway.t.sol
@@ -501,12 +501,6 @@ contract SetPeer is SetUp {
         exocoreGateway.setPeer(anotherClientChain, newPeer);
     }
 
-    function test_RevertWhen_ClientChainNotRegistered() public {
-        vm.startPrank(exocoreValidatorSet.addr);
-        vm.expectRevert(Errors.ExocoreGatewayNotRegisteredClientChainId.selector);
-        exocoreGateway.setPeer(anotherClientChain, newPeer);
-    }
-
 }
 
 contract AddWhitelistTokens is SetUp {
@@ -532,7 +526,7 @@ contract AddWhitelistTokens is SetUp {
 
         vm.startPrank(deployer.addr);
         vm.expectRevert("Ownable: caller is not the owner");
-        exocoreGateway.addWhitelistTokens{value: nativeFee}(
+        exocoreGateway.addOrUpdateWhitelistTokens{value: nativeFee}(
             clientChainId, whitelistTokens, decimals, tvlLimits, names, metaData
         );
     }
@@ -546,24 +540,8 @@ contract AddWhitelistTokens is SetUp {
         uint256 messageLength = TOKEN_ADDRESS_BYTES_LENGTH * whitelistTokens.length + 2;
         uint256 nativeFee = exocoreGateway.quote(clientChainId, new bytes(messageLength));
         vm.expectRevert("Pausable: paused");
-        exocoreGateway.addWhitelistTokens{value: nativeFee}(
+        exocoreGateway.addOrUpdateWhitelistTokens{value: nativeFee}(
             clientChainId, whitelistTokens, decimals, tvlLimits, names, metaData
-        );
-    }
-
-    function test_RevertWhen_ClientChainNotRegisteredBefore() public {
-        uint32 anotherClientChain = 3;
-        _prepareInputs(2);
-
-        uint256 messageLength = TOKEN_ADDRESS_BYTES_LENGTH * whitelistTokens.length + 2;
-        uint256 nativeFee = exocoreGateway.quote(clientChainId, new bytes(messageLength));
-
-        vm.startPrank(exocoreValidatorSet.addr);
-        vm.expectRevert(
-            abi.encodeWithSelector(ExocoreGatewayStorage.ClientChainIDNotRegisteredBefore.selector, anotherClientChain)
-        );
-        exocoreGateway.addWhitelistTokens{value: nativeFee}(
-            anotherClientChain, whitelistTokens, decimals, tvlLimits, names, metaData
         );
     }
 
@@ -575,7 +553,7 @@ contract AddWhitelistTokens is SetUp {
 
         vm.startPrank(exocoreValidatorSet.addr);
         vm.expectRevert(abi.encodeWithSelector(ExocoreGatewayStorage.WhitelistTokensListTooLong.selector));
-        exocoreGateway.addWhitelistTokens{value: nativeFee}(
+        exocoreGateway.addOrUpdateWhitelistTokens{value: nativeFee}(
             clientChainId, whitelistTokens, decimals, tvlLimits, names, metaData
         );
     }
@@ -589,7 +567,7 @@ contract AddWhitelistTokens is SetUp {
 
         vm.startPrank(exocoreValidatorSet.addr);
         vm.expectRevert(abi.encodeWithSelector(ExocoreGatewayStorage.InvalidWhitelistTokensInput.selector));
-        exocoreGateway.addWhitelistTokens{value: nativeFee}(
+        exocoreGateway.addOrUpdateWhitelistTokens{value: nativeFee}(
             clientChainId, whitelistTokens, decimals, tvlLimits, names, metaData
         );
     }
@@ -609,7 +587,7 @@ contract AddWhitelistTokens is SetUp {
 
         vm.startPrank(exocoreValidatorSet.addr);
         vm.expectRevert("ExocoreGateway: token cannot be zero address");
-        exocoreGateway.addWhitelistTokens{value: nativeFee}(
+        exocoreGateway.addOrUpdateWhitelistTokens{value: nativeFee}(
             clientChainId, whitelistTokens, decimals, tvlLimits, names, metaData
         );
     }
@@ -623,7 +601,7 @@ contract AddWhitelistTokens is SetUp {
 
         vm.startPrank(exocoreValidatorSet.addr);
         vm.expectRevert("ExocoreGateway: tvl limit should not be zero");
-        exocoreGateway.addWhitelistTokens{value: nativeFee}(
+        exocoreGateway.addOrUpdateWhitelistTokens{value: nativeFee}(
             clientChainId, whitelistTokens, decimals, tvlLimits, names, metaData
         );
     }
@@ -643,7 +621,7 @@ contract AddWhitelistTokens is SetUp {
         vm.expectEmit(true, true, true, true, address(exocoreGateway));
         emit WhitelistTokenAdded(clientChainId, whitelistTokens[0]);
         emit MessageSent(GatewayStorage.Action.REQUEST_ADD_WHITELIST_TOKENS, generateUID(1, false), 1, nativeFee);
-        exocoreGateway.addWhitelistTokens{value: nativeFee}(
+        exocoreGateway.addOrUpdateWhitelistTokens{value: nativeFee}(
             clientChainId, whitelistTokens, decimals, tvlLimits, names, metaData
         );
     }
@@ -689,7 +667,7 @@ contract UpdateWhitelistTokens is SetUp {
 
         vm.startPrank(deployer.addr);
         vm.expectRevert("Ownable: caller is not the owner");
-        exocoreGateway.updateWhitelistedTokens(clientChainId, whitelistTokens, decimals, tvlLimits, names, metaData);
+        exocoreGateway.addOrUpdateWhitelistTokens(clientChainId, whitelistTokens, decimals, tvlLimits, names, metaData);
     }
 
     function test_RevertWhen_Paused() public {
@@ -699,20 +677,7 @@ contract UpdateWhitelistTokens is SetUp {
         _prepareInputs(2);
 
         vm.expectRevert("Pausable: paused");
-        exocoreGateway.updateWhitelistedTokens(clientChainId, whitelistTokens, decimals, tvlLimits, names, metaData);
-    }
-
-    function test_RevertWhen_ClientChainNotRegisteredBefore() public {
-        uint32 anotherClientChain = 3;
-        _prepareInputs(2);
-
-        vm.startPrank(exocoreValidatorSet.addr);
-        vm.expectRevert(
-            abi.encodeWithSelector(ExocoreGatewayStorage.ClientChainIDNotRegisteredBefore.selector, anotherClientChain)
-        );
-        exocoreGateway.updateWhitelistedTokens(
-            anotherClientChain, whitelistTokens, decimals, tvlLimits, names, metaData
-        );
+        exocoreGateway.addOrUpdateWhitelistTokens(clientChainId, whitelistTokens, decimals, tvlLimits, names, metaData);
     }
 
     function test_RevertWhen_TokensListTooLong() public {
@@ -720,7 +685,7 @@ contract UpdateWhitelistTokens is SetUp {
 
         vm.startPrank(exocoreValidatorSet.addr);
         vm.expectRevert(abi.encodeWithSelector(ExocoreGatewayStorage.WhitelistTokensListTooLong.selector));
-        exocoreGateway.updateWhitelistedTokens(clientChainId, whitelistTokens, decimals, tvlLimits, names, metaData);
+        exocoreGateway.addOrUpdateWhitelistTokens(clientChainId, whitelistTokens, decimals, tvlLimits, names, metaData);
     }
 
     function test_RevertWhen_LengthNotMatch() public {
@@ -729,7 +694,7 @@ contract UpdateWhitelistTokens is SetUp {
 
         vm.startPrank(exocoreValidatorSet.addr);
         vm.expectRevert(abi.encodeWithSelector(ExocoreGatewayStorage.InvalidWhitelistTokensInput.selector));
-        exocoreGateway.updateWhitelistedTokens(clientChainId, whitelistTokens, decimals, tvlLimits, names, metaData);
+        exocoreGateway.addOrUpdateWhitelistTokens(clientChainId, whitelistTokens, decimals, tvlLimits, names, metaData);
     }
 
     function test_RevertWhen_HasZeroAddressToken() public {
@@ -752,7 +717,7 @@ contract UpdateWhitelistTokens is SetUp {
 
         vm.startPrank(exocoreValidatorSet.addr);
         vm.expectRevert("ExocoreGateway: token cannot be zero address");
-        exocoreGateway.updateWhitelistedTokens(clientChainId, whitelistTokens, decimals, tvlLimits, names, metaData);
+        exocoreGateway.addOrUpdateWhitelistTokens(clientChainId, whitelistTokens, decimals, tvlLimits, names, metaData);
     }
 
     function test_RevertWhen_HasZeroTVMLimit() public {
@@ -768,20 +733,7 @@ contract UpdateWhitelistTokens is SetUp {
 
         vm.startPrank(exocoreValidatorSet.addr);
         vm.expectRevert("ExocoreGateway: tvl limit should not be zero");
-        exocoreGateway.updateWhitelistedTokens(clientChainId, whitelistTokens, decimals, tvlLimits, names, metaData);
-    }
-
-    function test_RevertWhen_HasTokenNotRegisteredBefore() public {
-        _prepareInputs(1);
-        whitelistTokens[0] = bytes32(bytes20(address(restakeToken)));
-        decimals[0] = 18;
-        tvlLimits[0] = 1e10 ether;
-        names[0] = "RestakeToken";
-        metaData[0] = "ERC20 LST token";
-
-        vm.startPrank(exocoreValidatorSet.addr);
-        vm.expectRevert("ExocoreGateway: token has not been added to whitelist before");
-        exocoreGateway.updateWhitelistedTokens(clientChainId, whitelistTokens, decimals, tvlLimits, names, metaData);
+        exocoreGateway.addOrUpdateWhitelistTokens(clientChainId, whitelistTokens, decimals, tvlLimits, names, metaData);
     }
 
     function test_Success_UpdateWhitelistTokens() public {
@@ -800,7 +752,7 @@ contract UpdateWhitelistTokens is SetUp {
         vm.expectEmit(true, true, true, true, address(exocoreGateway));
         emit WhitelistTokenUpdated(clientChainId, whitelistTokens[0]);
         vm.startPrank(exocoreValidatorSet.addr);
-        exocoreGateway.updateWhitelistedTokens(clientChainId, whitelistTokens, decimals, tvlLimits, names, metaData);
+        exocoreGateway.addOrUpdateWhitelistTokens(clientChainId, whitelistTokens, decimals, tvlLimits, names, metaData);
     }
 
     function _prepareInputs(uint256 listLength) internal {
@@ -822,7 +774,7 @@ contract UpdateWhitelistTokens is SetUp {
         vm.startPrank(exocoreValidatorSet.addr);
         uint256 messageLength = TOKEN_ADDRESS_BYTES_LENGTH * whitelistTokens.length + 2;
         uint256 nativeFee = exocoreGateway.quote(clientChainId, new bytes(messageLength));
-        exocoreGateway.addWhitelistTokens{value: nativeFee}(
+        exocoreGateway.addOrUpdateWhitelistTokens{value: nativeFee}(
             clientChainId_, whitelistTokens_, decimals_, tvlLimits_, names_, metaData_
         );
         vm.stopPrank();

--- a/test/mocks/AssetsMock.sol
+++ b/test/mocks/AssetsMock.sol
@@ -50,35 +50,38 @@ contract AssetsMock is IAssets {
         return (true, chainIds);
     }
 
-    function registerClientChain(
+    function registerOrUpdateClientChain(
         uint32 clientChainId,
         uint8 addressLength,
         string calldata name,
         string calldata metaInfo,
         string calldata signatureType
-    ) external returns (bool) {
+    ) external returns (bool, bool) {
+        bool updated = isRegisteredChain[clientChainId];
         if (!isRegisteredChain[clientChainId]) {
             isRegisteredChain[clientChainId] = true;
             chainIds.push(clientChainId);
         }
-        return true;
+        return (true, updated);
     }
 
-    function registerToken(
+    function registerOrUpdateToken(
         uint32 clientChainId,
         bytes calldata token,
         uint8 decimals,
         uint256 tvlLimit,
         string calldata name,
         string calldata metaData
-    ) external returns (bool) {
+    ) external returns (bool success, bool updated) {
         require(isRegisteredChain[clientChainId], "the chain is not registered before");
 
-        if (!isRegisteredToken[clientChainId][token]) {
+        updated = isRegisteredToken[clientChainId][token];
+
+        if (!updated) {
             isRegisteredToken[clientChainId][token] = true;
         }
 
-        return true;
+        return (true, updated);
     }
 
     function getPrincipalBalance(uint32 clientChainLzId, bytes memory token, bytes memory staker)

--- a/test/mocks/AssetsMock.sol
+++ b/test/mocks/AssetsMock.sol
@@ -65,7 +65,7 @@ contract AssetsMock is IAssets {
         return (true, updated);
     }
 
-    function registerOrUpdateToken(
+    function registerOrUpdateTokens(
         uint32 clientChainId,
         bytes calldata token,
         uint8 decimals,

--- a/test/mocks/AssetsMock.sol
+++ b/test/mocks/AssetsMock.sol
@@ -96,4 +96,8 @@ contract AssetsMock is IAssets {
         return abi.encodePacked(bytes32(bytes20(addr)));
     }
 
+    function isRegisteredClientChain(uint32 clientChainID) external view returns (bool, bool) {
+        return (true, isRegisteredChain[clientChainID]);
+    }
+
 }

--- a/test/mocks/ExocoreGatewayMock.sol
+++ b/test/mocks/ExocoreGatewayMock.sol
@@ -194,7 +194,7 @@ contract ExocoreGatewayMock is
             require(bytes(names[i]).length != 0, "ExocoreGateway: name cannot be empty");
             require(bytes(metaData[i]).length != 0, "ExocoreGateway: meta data cannot be empty");
 
-            (success, updated) = ASSETS_CONTRACT.registerOrUpdateToken(
+            (success, updated) = ASSETS_CONTRACT.registerOrUpdateTokens(
                 clientChainId, abi.encodePacked(tokens[i]), decimals[i], tvlLimits[i], names[i], metaData[i]
             );
 

--- a/test/mocks/ExocoreGatewayMock.sol
+++ b/test/mocks/ExocoreGatewayMock.sol
@@ -22,6 +22,7 @@ import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Own
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
 import {ReentrancyGuardUpgradeable} from "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
+import {Errors} from "src/libraries/Errors.sol";
 import {OAppCoreUpgradeable} from "src/lzApp/OAppCoreUpgradeable.sol";
 
 contract ExocoreGatewayMock is
@@ -170,6 +171,7 @@ contract ExocoreGatewayMock is
         onlyOwner
         whenNotPaused
     {
+        _validateClientChainIdRegistered(clientChainId);
         super.setPeer(clientChainId, clientChainGateway);
     }
 
@@ -240,6 +242,16 @@ contract ExocoreGatewayMock is
                 || metaData.length != expectedLength
         ) {
             revert InvalidWhitelistTokensInput();
+        }
+    }
+
+    function _validateClientChainIdRegistered(uint32 clientChainId) internal view {
+        (bool success, bool isRegistered) = ASSETS_CONTRACT.isRegisteredClientChain(clientChainId);
+        if (!success) {
+            revert Errors.ExocoreGatewayFailedToCheckClientChainId();
+        }
+        if (!isRegistered) {
+            revert Errors.ExocoreGatewayNotRegisteredClientChainId();
         }
     }
 


### PR DESCRIPTION
The `ExocoreGateway` allows the contract owner to call precompiles which allow the registration of a client chain or a token. It also enables updates of these items. To check whether a request is an update or an addition, it relies on the ExocoreGateway keeping a copy of registered items. However, this does not work for items which were registered at genesis.

This PR works around that problem by requiring that the single source of truth be the precompiles, whose responsibility is to report if a request was an update or an addition.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Consolidated token management functionality, allowing for both addition and updating of tokens with a single function.
  - Enhanced clarity in client chain registration processes, now allowing for updates in addition to registrations.
  - Introduced new methods for checking registration status of client chains.

- **Documentation**
  - Updated the contracts owner manual for improved clarity on token management processes.

- **Bug Fixes**
  - Improved input validation for token management functions, ensuring better handling of erroneous inputs.

- **Refactor**
  - Streamlined various function signatures and error handling logic across multiple contracts to enhance maintainability and clarity.

- **Chores**
  - Removed outdated mappings and error declarations to simplify contract logic and improve functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->