### PR TITLE
chore: enable checks being run on merge queue

### DIFF
--- a/.github/workflows/forge-ci.yml
+++ b/.github/workflows/forge-ci.yml
@@ -2,6 +2,7 @@
 name: Forge CI to build, test and format
 
 on:
+  merge_group:
   pull_request:
   push:
     branches:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,7 @@
 name: Run `solhint` linter
 
-on: 
+on:
+  merge_group:
   pull_request:
   push:
     branches:

--- a/.github/workflows/slither.yml
+++ b/.github/workflows/slither.yml
@@ -1,6 +1,7 @@
 name: Slither Analysis
 
 on:
+  merge_group:
   pull_request:
   push:
     branches:


### PR DESCRIPTION
## Description

As described in comment https://github.com/ExocoreNetwork/exocore-contracts/pull/66#discussion_r1696535071, the checks would not be re-run when another pull request gets merged before merging a pull request. To enable checks being automatically re-run even if no new commit is pushed, we have set the main branch protection rules to require merge queue, and this pull request add `merge_group` to workflow files to trigger these checks for merge queue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new event trigger, `merge_group`, to the CI workflows, enhancing responsiveness to specific repository activities.
	- Improved the execution of the linter and Slither analysis by adding support for the `merge_group` event.

These changes provide more granular control over when CI processes run, potentially improving workflow efficiency and issue detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->