### PR TITLE
doc: comment to notice compatible LST token type

### DIFF
--- a/src/core/ExocoreGateway.sol
+++ b/src/core/ExocoreGateway.sol
@@ -170,10 +170,13 @@ contract ExocoreGateway is
     }
 
     /// @inheritdoc IExocoreGateway
-    /// @dev tokens can only be normal reward-bearong LST tokens like wstETH, eETH, jitoSol...
+    /// @notice Tokens can only be normal reward-bearong LST tokens like wstETH, eETH, jitoSol...
     /// And they are not intended to be: 1) rebasing tokens like stETH, since we assume staker's
     /// balance would not change if nothing is done after deposit, 2) fee-on-transfer tokens, since we
     /// assume Vault would count for the amount that staker transfers to it.
+    /// @notice If we want to activate client chain's native restaking, we should add the corresponding virtual
+    /// token address to the whitelist, bytes32(bytes20(0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE)) for Ethereum
+    /// native restaking for example.
     function addOrUpdateWhitelistTokens(
         uint32 clientChainId,
         bytes32[] calldata tokens,

--- a/src/core/ExocoreGateway.sol
+++ b/src/core/ExocoreGateway.sol
@@ -170,6 +170,10 @@ contract ExocoreGateway is
     }
 
     /// @inheritdoc IExocoreGateway
+    /// @dev tokens can only be normal reward-bearong LST tokens like wstETH, eETH, jitoSol...
+    /// And they are not intended to be: 1) rebasing tokens like stETH, since we assume staker's
+    /// balance would not change if nothing is done after deposit, 2) fee-on-transfer tokens, since we
+    /// assume Vault would count for the amount that staker transfers to it.
     function addOrUpdateWhitelistTokens(
         uint32 clientChainId,
         bytes32[] calldata tokens,

--- a/src/core/Vault.sol
+++ b/src/core/Vault.sol
@@ -34,6 +34,10 @@ contract Vault is Initializable, VaultStorage, IVault {
     /// @notice Initializes the Vault contract.
     /// @param underlyingToken_ The address of the underlying token.
     /// @param gateway_ The address of the gateway contract.
+    /// @dev Vault only works with normal ERC20 like reward-bearing LST tokens like wstETH, eETH.
+    /// And It is not intended to be used for: 1) rebasing token like stETH, since we assume staker's
+    /// balance would not change if nothing is done after deposit, 2) fee-on-transfer token, since we
+    /// assume Vault would count for the amount that staker transfers to it.
     function initialize(address underlyingToken_, address gateway_) external initializer {
         if (underlyingToken_ == address(0) || gateway_ == address(0)) {
             revert Errors.ZeroAddress();


### PR DESCRIPTION
## Description

closes: #1 

we should notice the contract caller the compatible types of LST tokens and escape incompatible LST tokens, but also notice caller to add virtual token address to activate native restaking