### PR TITLE
refactor: use receipt's nonce instead of outboundNonce

### DIFF
--- a/src/storage/ClientChainGatewayStorage.sol
+++ b/src/storage/ClientChainGatewayStorage.sol
@@ -16,9 +16,6 @@ import {IBeacon} from "@openzeppelin/contracts/proxy/beacon/IBeacon.sol";
 /// ClientChainGateway contract. Shared items should be kept in BootstrapStorage.
 contract ClientChainGatewayStorage is BootstrapStorage {
 
-    /// @notice The nonce for outbound messages.
-    uint64 public outboundNonce;
-
     /// @notice Mapping of owner addresses to their corresponding ExoCapsule contracts.
     mapping(address => IExoCapsule) public ownerToCapsule;
 


### PR DESCRIPTION
## Description

closes: #22 

When we call `_lzSend` to send message to Exocore in ClientChainGateway, it would return the receipt which includes nonce, which is exactly the outbound nonce returned by layerzero endpoint v2

``` solidity
contract EndpointV2 {
function _send(
        address _sender,
        MessagingParams calldata _params
    ) internal returns (MessagingReceipt memory, address) {
        // get the correct outbound nonce
        uint64 latestNonce = _outbound(_sender, _params.dstEid, _params.receiver);

       .....

        return (MessagingReceipt(packet.guid, latestNonce, fee), _sendLibrary);
    }

function _outbound(address _sender, uint32 _dstEid, bytes32 _receiver) internal returns (uint64 nonce) {
        unchecked {
            nonce = ++outboundNonce[_sender][_dstEid][_receiver];
        }
    }
}
```

so we could use this nonce as request ID instead of maintaining the outbound nonce in ClientChainGateway

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced nonce management in the request handling process for improved clarity and efficiency.
  
- **Bug Fixes**
	- Removed the outboundNonce state variable to simplify state management and potentially reduce gas costs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->