### PR TITLE
fix: fix wrongly used withdrawal index for proven withdrawal

### DIFF
--- a/script/13_DepositValidator.s.sol
+++ b/script/13_DepositValidator.s.sol
@@ -13,6 +13,7 @@ import "@layerzerolabs/lz-evm-protocol-v2/contracts/libs/GUID.sol";
 import {ERC20PresetFixedSupply} from "@openzeppelin/contracts/token/ERC20/presets/ERC20PresetFixedSupply.sol";
 import "forge-std/Script.sol";
 
+import "src/libraries/BeaconChainProofs.sol";
 import "src/libraries/Endian.sol";
 
 import {BaseScript} from "./BaseScript.sol";
@@ -24,7 +25,7 @@ contract DepositScript is BaseScript {
     using Endian for bytes32;
 
     bytes32[] validatorContainer;
-    IExoCapsule.ValidatorContainerProof validatorProof;
+    BeaconChainProofs.ValidatorContainerProof validatorProof;
 
     uint256 internal constant GENESIS_BLOCK_TIMESTAMP = 1_695_902_400;
     uint256 internal constant SECONDS_PER_SLOT = 12;

--- a/src/core/ExoCapsule.sol
+++ b/src/core/ExoCapsule.sol
@@ -223,7 +223,7 @@ contract ExoCapsule is ReentrancyGuardUpgradeable, ExoCapsuleStorage, IExoCapsul
             revert WithdrawalAlreadyProven(validatorPubkey, withdrawalProof.withdrawalIndex);
         }
 
-        provenWithdrawal[validatorPubkey][withdrawalProof.withdrawalIndex] = true;
+        provenWithdrawal[validatorPubkey][uint256(withdrawalContainer.getWithdrawalIndex())] = true;
 
         // Validate if validator and withdrawal proof state roots are the same
         if (validatorProof.stateRoot != withdrawalProof.stateRoot) {

--- a/src/core/NativeRestakingController.sol
+++ b/src/core/NativeRestakingController.sol
@@ -94,7 +94,7 @@ abstract contract NativeRestakingController is
     /// @param proof The proof of the validator container.
     function depositBeaconChainValidator(
         bytes32[] calldata validatorContainer,
-        IExoCapsule.ValidatorContainerProof calldata proof
+        BeaconChainProofs.ValidatorContainerProof calldata proof
     ) external payable whenNotPaused nonReentrant nativeRestakingEnabled {
         IExoCapsule capsule = _getCapsule(msg.sender);
         uint256 depositValue = capsule.verifyDepositProof(validatorContainer, proof);
@@ -112,7 +112,7 @@ abstract contract NativeRestakingController is
     /// @param withdrawalProof The proof of the withdrawal.
     function processBeaconChainWithdrawal(
         bytes32[] calldata validatorContainer,
-        IExoCapsule.ValidatorContainerProof calldata validatorProof,
+        BeaconChainProofs.ValidatorContainerProof calldata validatorProof,
         bytes32[] calldata withdrawalContainer,
         BeaconChainProofs.WithdrawalProof calldata withdrawalProof
     ) external payable whenNotPaused nonReentrant nativeRestakingEnabled {

--- a/src/interfaces/IExoCapsule.sol
+++ b/src/interfaces/IExoCapsule.sol
@@ -9,22 +9,6 @@ import {BeaconChainProofs} from "../libraries/BeaconChainProofs.sol";
 /// operations. It is a contract used for native restaking.
 interface IExoCapsule {
 
-    /// @notice This struct contains the information needed for validator container validity verification
-    struct ValidatorContainerProof {
-        uint256 beaconBlockTimestamp;
-        bytes32 stateRoot;
-        bytes32[] stateRootProof;
-        bytes32[] validatorContainerRootProof;
-        uint256 validatorIndex;
-    }
-
-    /// @notice This struct contains the information needed for withdrawal container proof verification
-    struct WithdrawalContainerProof {
-        uint256 beaconBlockTimestamp;
-        bytes32 stateRoot;
-        bytes32[] withdrawalContainerRootProof;
-    }
-
     /// @notice Initializes the ExoCapsule contract with the given parameters.
     /// @param gateway The address of the ClientChainGateway contract.
     /// @param capsuleOwner The address of the ExoCapsule owner.
@@ -38,9 +22,10 @@ interface IExoCapsule {
     /// @dev The container must not have been previously registered, must not be stale,
     /// must be activated at a previous epoch, must have the correct withdrawal credentials,
     /// and must have a valid container root.
-    function verifyDepositProof(bytes32[] calldata validatorContainer, ValidatorContainerProof calldata proof)
-        external
-        returns (uint256);
+    function verifyDepositProof(
+        bytes32[] calldata validatorContainer,
+        BeaconChainProofs.ValidatorContainerProof calldata proof
+    ) external returns (uint256);
 
     /// @notice Verifies the withdrawal proof and returns the partial withdrawal status and the withdrawal amount.
     /// @param validatorContainer The validator container.
@@ -55,7 +40,7 @@ interface IExoCapsule {
     /// withdrawable epoch of the validator.
     function verifyWithdrawalProof(
         bytes32[] calldata validatorContainer,
-        ValidatorContainerProof calldata validatorProof,
+        BeaconChainProofs.ValidatorContainerProof calldata validatorProof,
         bytes32[] calldata withdrawalContainer,
         BeaconChainProofs.WithdrawalProof calldata withdrawalProof
     ) external returns (bool partialWithdrawal, uint256 withdrawalAmount);

--- a/src/interfaces/INativeRestakingController.sol
+++ b/src/interfaces/INativeRestakingController.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.19;
 
 import {BeaconChainProofs} from "../libraries/BeaconChainProofs.sol";
 import {IBaseRestakingController} from "./IBaseRestakingController.sol";
-import {IExoCapsule} from "./IExoCapsule.sol";
 
 /// @title INativeRestakingController
 /// @author ExocoreNetwork

--- a/src/interfaces/INativeRestakingController.sol
+++ b/src/interfaces/INativeRestakingController.sol
@@ -35,7 +35,7 @@ interface INativeRestakingController is IBaseRestakingController {
     /// @param proof The proof needed to verify the validator container.
     function depositBeaconChainValidator(
         bytes32[] calldata validatorContainer,
-        IExoCapsule.ValidatorContainerProof calldata proof
+        BeaconChainProofs.ValidatorContainerProof calldata proof
     ) external payable;
 
     /// @notice Processes a partial withdrawal from the beacon chain to an ExoCapsule contract.
@@ -52,7 +52,7 @@ interface INativeRestakingController is IBaseRestakingController {
     /// block root.
     function processBeaconChainWithdrawal(
         bytes32[] calldata validatorContainer,
-        IExoCapsule.ValidatorContainerProof calldata validatorProof,
+        BeaconChainProofs.ValidatorContainerProof calldata validatorProof,
         bytes32[] calldata withdrawalContainer,
         BeaconChainProofs.WithdrawalProof calldata withdrawalProof
     ) external payable;

--- a/src/libraries/BeaconChainProofs.sol
+++ b/src/libraries/BeaconChainProofs.sol
@@ -72,6 +72,15 @@ library BeaconChainProofs {
     // slither-disable-next-line unused-state
     uint64 internal constant SECONDS_PER_EPOCH = SLOTS_PER_EPOCH * SECONDS_PER_SLOT;
 
+    /// @notice This struct contains the information needed for validator container validity verification
+    struct ValidatorContainerProof {
+        uint256 beaconBlockTimestamp;
+        uint256 validatorIndex;
+        bytes32 stateRoot;
+        bytes32[] stateRootProof;
+        bytes32[] validatorContainerRootProof;
+    }
+
     /// @notice This struct contains the merkle proofs and leaves needed to verify a partial/full withdrawal
     struct WithdrawalProof {
         bytes32[] withdrawalContainerRootProof;

--- a/test/foundry/ExocoreDeployer.t.sol
+++ b/test/foundry/ExocoreDeployer.t.sol
@@ -81,7 +81,7 @@ contract ExocoreDeployer is Test {
 
     bytes32[] validatorContainer;
     bytes32 beaconBlockRoot; // latest beacon block root
-    IExoCapsule.ValidatorContainerProof validatorProof;
+    BeaconChainProofs.ValidatorContainerProof validatorProof;
 
     bytes32[] withdrawalContainer;
     BeaconChainProofs.WithdrawalProof withdrawalProof;

--- a/test/foundry/unit/ExoCapsule.t.sol
+++ b/test/foundry/unit/ExoCapsule.t.sol
@@ -28,7 +28,7 @@ contract DepositSetup is Test {
      *         uint256 validatorContainerRootIndex;
      *     }
      */
-    IExoCapsule.ValidatorContainerProof validatorProof;
+    BeaconChainProofs.ValidatorContainerProof validatorProof;
     bytes32 beaconBlockRoot;
 
     ExoCapsule capsule;
@@ -312,7 +312,7 @@ contract WithdrawalSetup is Test {
      *     uint256 validatorIndex;
      * }
      */
-    IExoCapsule.ValidatorContainerProof validatorProof;
+    BeaconChainProofs.ValidatorContainerProof validatorProof;
 
     bytes32[] withdrawalContainer;
     BeaconChainProofs.WithdrawalProof withdrawalProof;
@@ -466,11 +466,16 @@ contract WithdrawalSetup is Test {
         return vc[6].fromLittleEndianUint64();
     }
 
+    function _getWithdrawalIndex(bytes32[] storage wc) internal view returns (uint64) {
+        return wc[0].fromLittleEndianUint64();
+    }
+
 }
 
 contract VerifyWithdrawalProof is WithdrawalSetup {
 
     using BeaconChainProofs for bytes32;
+    using WithdrawalContainer for bytes32[];
     using stdStorage for StdStorage;
 
     function test_NonBeaconChainETHWithdraw() public {
@@ -510,7 +515,7 @@ contract VerifyWithdrawalProof is WithdrawalSetup {
             abi.encodeWithSelector(
                 ExoCapsule.WithdrawalAlreadyProven.selector,
                 _getPubkey(validatorContainer),
-                withdrawalProof.withdrawalIndex
+                uint256(_getWithdrawalIndex(withdrawalContainer))
             )
         );
         capsule.verifyWithdrawalProof(validatorContainer, validatorProof, withdrawalContainer, withdrawalProof);

--- a/test/mocks/NonShortCircuitEndpointV2Mock.sol
+++ b/test/mocks/NonShortCircuitEndpointV2Mock.sol
@@ -717,8 +717,9 @@ contract NonShortCircuitEndpointV2Mock is ILayerZeroEndpointV2, MessagingContext
                 }
             } else if (optionType == ExecutorOptions.OPTION_TYPE_ORDERED_EXECUTION) {
                 // ordered = true;
+            } else {
+                revert IExecutorFeeLib.Executor_UnsupportedOptionType(optionType);
             }
-            else revert IExecutorFeeLib.Executor_UnsupportedOptionType(optionType);
         }
 
         if (cursor != _options.length) {

--- a/test/mocks/NonShortCircuitEndpointV2Mock.sol
+++ b/test/mocks/NonShortCircuitEndpointV2Mock.sol
@@ -717,7 +717,8 @@ contract NonShortCircuitEndpointV2Mock is ILayerZeroEndpointV2, MessagingContext
                 }
             } else if (optionType == ExecutorOptions.OPTION_TYPE_ORDERED_EXECUTION) {
                 // ordered = true;
-            } else {
+            }
+            else {
                 revert IExecutorFeeLib.Executor_UnsupportedOptionType(optionType);
             }
         }


### PR DESCRIPTION
## Description

closes: #75 

- [x] replace `provenWithdrawal[validatorPubkey][withdrawalProof.withdrawalIndex]` with `provenWithdrawal[validatorPubkey][withdrawalId]`, where `withdrawalId = uint256(withdrawalContainer.getWithdrawalIndex())`
- [x] move `ValidatorContainerProof` to `BeaconChainProof.lib` to be consistent with withdrawal proof
- [x] fix tests and scripts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new struct for improved validation processes.
	- Enhanced withdrawal index management with a new internal function in the WithdrawalSetup contract.

- **Bug Fixes**
	- Improved error handling in the NonShortCircuitEndpointV2Mock contract, enhancing robustness.

- **Refactor**
	- Updated multiple contracts and interfaces to utilize the new validator proof type for better consistency and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->