### PR TITLE
feat: submit reward must be successful on exocore chain

### DIFF
--- a/src/core/ExocoreGateway.sol
+++ b/src/core/ExocoreGateway.sol
@@ -414,6 +414,9 @@ contract ExocoreGateway is
         } else {
             (success,) = REWARD_CONTRACT.claimReward(srcChainId, token, avsOrWithdrawer, amount);
         }
+        if (isSubmitReward && !success) {
+            revert Errors.DepositRequestShouldNotFail(srcChainId, lzNonce); // we should not let this happen
+        }
         emit RewardOperation(isSubmitReward, success, bytes32(token), bytes32(avsOrWithdrawer), amount);
 
         response = isSubmitReward ? bytes("") : abi.encodePacked(lzNonce, success);


### PR DESCRIPTION
## Description

To follow our design principal, we should assume that `submitReward` must be successful

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling for reward submissions in the ExocoreGateway contract.
  
- **Bug Fixes**
	- Improved integrity of reward operations by preventing unexpected failures during submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->