### PR TITLE
update executor options for solana client controller

### DIFF
--- a/src/core/ExocoreGateway.sol
+++ b/src/core/ExocoreGateway.sol
@@ -552,15 +552,13 @@ contract ExocoreGateway is
     /// @return options The built options
     function _buildOptions(uint32 srcChainId, Action act) private pure returns (bytes memory) {
         bytes memory options = OptionsBuilder.newOptions();
+        uint128 value = DESTINATION_MSG_VALUE;
 
         if (!_isSolana(srcChainId)) {
-            // currently, LZ does not support ordered execution for Solana
             options = options.addExecutorOrderedExecutionOption();
+        } else if (act == Action.REQUEST_ADD_WHITELIST_TOKEN) {
+            value = SOLANA_WHITELIST_TOKEN_MSG_VALUE;
         }
-
-        uint128 value = _isSolana(srcChainId) && act == Action.REQUEST_ADD_WHITELIST_TOKEN
-            ? SOLANA_WHITELIST_TOKEN_MSG_VALUE
-            : DESTINATION_MSG_VALUE;
 
         options = options.addExecutorLzReceiveOption(DESTINATION_GAS_LIMIT, value);
 

--- a/src/core/ExocoreGateway.sol
+++ b/src/core/ExocoreGateway.sol
@@ -553,14 +553,12 @@ contract ExocoreGateway is
     function _buildOptions(uint32 srcChainId, Action act) private pure returns (bytes memory) {
         bytes memory options = OptionsBuilder.newOptions();
 
-        bool isSolana = srcChainId == SOLANA_DEVNET_CHAIN_ID || srcChainId == SOLANA_MAINNET_CHAIN_ID;
-
-        if (!isSolana) {
+        if (!_isSolana(srcChainId)) {
             // currently, LZ does not support ordered execution for Solana
             options = options.addExecutorOrderedExecutionOption();
         }
 
-        uint128 value = isSolana && act == Action.REQUEST_ADD_WHITELIST_TOKEN
+        uint128 value = _isSolana(srcChainId) && act == Action.REQUEST_ADD_WHITELIST_TOKEN
             ? SOLANA_WHITELIST_TOKEN_MSG_VALUE
             : DESTINATION_MSG_VALUE;
 

--- a/src/core/ExocoreGateway.sol
+++ b/src/core/ExocoreGateway.sol
@@ -354,7 +354,7 @@ contract ExocoreGateway is
         }
         emit LSTTransfer(isDeposit, success, bytes32(token), bytes32(staker), amount);
 
-        if (srcChainId == SOLANA_DEVNET_CHAIN_ID || srcChainId == SOLANA_MAINNET_CHAIN_ID) {
+        if (_isSolana(srcChainId)) {
             response = isDeposit ? bytes("") : abi.encodePacked(lzNonce, success, bytes32(token), bytes32(staker));
         } else {
             response = isDeposit ? bytes("") : abi.encodePacked(lzNonce, success);
@@ -423,7 +423,7 @@ contract ExocoreGateway is
         }
         emit RewardOperation(isSubmitReward, success, bytes32(token), bytes32(avsOrWithdrawer), amount);
 
-        if (srcChainId == SOLANA_DEVNET_CHAIN_ID || srcChainId == SOLANA_MAINNET_CHAIN_ID) {
+        if (_isSolana(srcChainId)) {
             response = isSubmitReward
                 ? bytes("")
                 : abi.encodePacked(lzNonce, success, bytes32(token), bytes32(avsOrWithdrawer));

--- a/src/storage/ExocoreGatewayStorage.sol
+++ b/src/storage/ExocoreGatewayStorage.sol
@@ -19,6 +19,17 @@ contract ExocoreGatewayStorage is GatewayStorage {
     /// @dev The msg.value for all the destination chains.
     uint128 internal constant DESTINATION_MSG_VALUE = 0;
 
+    /// constants used for solana mainnet chainId
+    /// @dev the solana mainnet chain id
+    uint32 internal constant SOLANA_MAINNET_CHAIN_ID = 30_168;
+
+    /// constants used for solana devnet chainId
+    /// @dev the solana devnet chain id
+    uint32 internal constant SOLANA_DEVNET_CHAIN_ID = 40_168;
+
+    /// @dev the msg.value for send addTokenWhiteList message
+    uint128 internal constant SOLANA_MSG_VALUE = 3_000_000;
+
     /// @notice Emitted when a precompile call fails.
     /// @param precompile Address of the precompile contract.
     /// @param nonce The LayerZero nonce

--- a/src/storage/ExocoreGatewayStorage.sol
+++ b/src/storage/ExocoreGatewayStorage.sol
@@ -139,4 +139,12 @@ contract ExocoreGatewayStorage is GatewayStorage {
         }
     }
 
+    /**
+     * @dev return true if chain is either Solana devnet or Solana mainnet
+     * @param srcChainId remote Chain Id
+     */
+    function _isSolana(uint32 srcChainId) internal pure returns (bool) {
+        return srcChainId == SOLANA_DEVNET_CHAIN_ID || srcChainId == SOLANA_MAINNET_CHAIN_ID;
+    }
+
 }

--- a/test/foundry/unit/ExocoreGateway.t.sol
+++ b/test/foundry/unit/ExocoreGateway.t.sol
@@ -147,19 +147,11 @@ contract SetUp is Test {
                 nonce, clientChainId, address(clientGateway), exocoreChainId, address(exocoreGateway).toBytes32()
             );
         } else {
-            if (isSolanaClient) {
-                uid = GUID.generate(
-                    nonce,
-                    exocoreChainId,
-                    address(exocoreGateway),
-                    solanaClientChainId,
-                    address(solanaClientGateway).toBytes32()
-                );
-            } else {
-                uid = GUID.generate(
-                    nonce, exocoreChainId, address(exocoreGateway), clientChainId, address(clientGateway).toBytes32()
-                );
-            }
+            uint16 targetChainId = isSolanaClient ? solanaClientChainId : clientChainId;
+            bytes32 targetGateway =
+                isSolanaClient ? address(solanaClientGateway).toBytes32() : address(clientGateway).toBytes32();
+
+            return GUID.generate(nonce, exocoreChainId, address(exocoreGateway), targetChainId, targetGateway);
         }
     }
 

--- a/test/foundry/unit/ExocoreGateway.t.sol
+++ b/test/foundry/unit/ExocoreGateway.t.sol
@@ -134,36 +134,30 @@ contract SetUp is Test {
     }
 
     function generateUID(uint64 nonce, bool fromClientChainToExocore) internal view returns (bytes32 uid) {
-        uid = generateUID(nonce, fromClientChainToExocore, true);
+        uid = generateUID(nonce, fromClientChainToExocore, false);
     }
 
-    function generateUID(uint64 nonce, bool fromClientChainToExocore, bool isEVM) internal view returns (bytes32 uid) {
+    function generateUID(uint64 nonce, bool fromClientChainToExocore, bool isSolanaClient)
+        internal
+        view
+        returns (bytes32 uid)
+    {
         if (fromClientChainToExocore) {
-            if (isEVM) {
-                uid = GUID.generate(
-                    nonce, clientChainId, address(clientGateway), exocoreChainId, address(exocoreGateway).toBytes32()
-                );
-            } else {
-                uid = GUID.generate(
-                    nonce,
-                    solanaClientChainId,
-                    address(solanaClientGateway),
-                    exocoreChainId,
-                    address(exocoreGateway).toBytes32()
-                );
-            }
+            uid = GUID.generate(
+                nonce, clientChainId, address(clientGateway), exocoreChainId, address(exocoreGateway).toBytes32()
+            );
         } else {
-            if (isEVM) {
-                uid = GUID.generate(
-                    nonce, exocoreChainId, address(exocoreGateway), clientChainId, address(clientGateway).toBytes32()
-                );
-            } else {
+            if (isSolanaClient) {
                 uid = GUID.generate(
                     nonce,
                     exocoreChainId,
                     address(exocoreGateway),
                     solanaClientChainId,
                     address(solanaClientGateway).toBytes32()
+                );
+            } else {
+                uid = GUID.generate(
+                    nonce, exocoreChainId, address(exocoreGateway), clientChainId, address(clientGateway).toBytes32()
                 );
             }
         }
@@ -638,7 +632,7 @@ contract AddWhitelistTokens is SetUp {
         vm.expectEmit(address(exocoreGateway));
         emit WhitelistTokenAdded(solanaClientChainId, bytes32(bytes20(address(restakeToken))));
         vm.expectEmit(address(exocoreGateway));
-        emit MessageSent(Action.REQUEST_ADD_WHITELIST_TOKEN, generateUID(1, false, false), 1, nativeFeeForSolana);
+        emit MessageSent(Action.REQUEST_ADD_WHITELIST_TOKEN, generateUID(1, false, true), 1, nativeFeeForSolana);
         exocoreGateway.addWhitelistToken{value: nativeFeeForSolana}(
             solanaClientChainId,
             bytes32(bytes20(address(restakeToken))),


### PR DESCRIPTION
update for #119 :
    add definition of Solana devnet & mainnet ChinaID
    set unordered options when sending message to Solana Chain
    set value when calling addWhitelistToken to add token on Solana Chain

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced response handling for token transfers and reward operations, providing additional context for specific chain actions.
	- Introduced constants for Solana blockchain messaging operations.
	- Added support for interactions with Solana client chains in the testing framework.

- **Bug Fixes**
	- Improved interchain communication logic for better functionality.

- **Documentation**
	- Updated function signatures to reflect new response formats and conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->