### PR TITLE
refactoring: Refactor ExocoreBTCGateway to work with multiple tokens

### DIFF
--- a/slither.config.json
+++ b/slither.config.json
@@ -1,5 +1,5 @@
 {
-    "detectors_to_exclude": "pragma,assembly,solc-version,naming-convention,timestamp,low-level-calls,too-many-digits,similar-names,calls-loop,reentrancy-benign,reentrancy-events,dead-code",
+    "detectors_to_exclude": "pragma,assembly,solc-version,naming-convention,timestamp,low-level-calls,too-many-digits,similar-names,calls-loop,reentrancy-benign,reentrancy-events,dead-code,mapping-deletion",
     "filter_paths": "lib/|test/|mocks/|BytesLib|script/",
     "solc_remaps": [
         "forge-std/=lib/forge-std/src/",

--- a/src/libraries/Errors.sol
+++ b/src/libraries/Errors.sol
@@ -324,4 +324,28 @@ library Errors {
     /// @dev ExocoreBtcGateway: transaction tag has already been processed
     error TxTagAlreadyProcessed();
 
+    /// @dev ExocoreBtcGateway: invalid operator address
+    error InvalidOperator();
+
+    /// @dev ExocoreBtcGateway: witness has already been authorized
+    error WitnessAlreadyAuthorized(address witness);
+
+    /// @dev ExocoreBtcGateway: witness has not been authorized
+    error WitnessNotAuthorized(address witness);
+
+    /// @dev ExocoreBtcGateway: cannot remove the last witness
+    error CannotRemoveLastWitness();
+
+    /// @dev ExocoreBtcGateway: invalid client chain
+    error InvalidClientChain();
+
+    /// @dev ExocoreBtcGateway: deposit failed
+    error DepositFailed(bytes txTag);
+
+    /// @dev ExocoreBtcGateway: address not registered
+    error AddressNotRegistered();
+
+    /// @dev ExocoreBtcGateway: delegation failed
+    error DelegationFailed();
+
 }

--- a/src/libraries/Errors.sol
+++ b/src/libraries/Errors.sol
@@ -364,7 +364,7 @@ library Errors {
     error RequestNotFound(uint64 requestId);
 
     /// @dev ExocoreBtcGateway: request already exists
-    error RequestAlreadyExists(uint64 requestId);
+    error RequestAlreadyExists(uint32 clientChain, uint64 requestId);
 
     /// @dev ExocoreBtcGateway: witness not authorized
     error UnauthorizedWitness();

--- a/src/libraries/Errors.sol
+++ b/src/libraries/Errors.sol
@@ -318,4 +318,10 @@ library Errors {
     /// @dev ExocoreBtcGateway: witness has already submitted proof
     error WitnessAlreadySubmittedProof();
 
+    /// @dev ExocoreBtcGateway: invalid stake message
+    error InvalidStakeMessage();
+
+    /// @dev ExocoreBtcGateway: transaction tag has already been processed
+    error TxTagAlreadyProcessed();
+
 }

--- a/src/libraries/Errors.sol
+++ b/src/libraries/Errors.sol
@@ -327,6 +327,9 @@ library Errors {
     /// @dev ExocoreBtcGateway: invalid operator address
     error InvalidOperator();
 
+    /// @dev ExocoreBtcGateway: invalid token
+    error InvalidToken();
+
     /// @dev ExocoreBtcGateway: witness has already been authorized
     error WitnessAlreadyAuthorized(address witness);
 
@@ -347,5 +350,23 @@ library Errors {
 
     /// @dev ExocoreBtcGateway: delegation failed
     error DelegationFailed();
+
+    /// @dev ExocoreBtcGateway: withdraw principal failed
+    error WithdrawPrincipalFailed();
+
+    /// @dev ExocoreBtcGateway: undelegation failed
+    error UndelegationFailed();
+
+    /// @dev ExocoreBtcGateway: withdraw reward failed
+    error WithdrawRewardFailed();
+
+    /// @dev ExocoreBtcGateway: request not found
+    error RequestNotFound(uint64 requestId);
+
+    /// @dev ExocoreBtcGateway: request already exists
+    error RequestAlreadyExists(uint64 requestId);
+
+    /// @dev ExocoreBtcGateway: witness not authorized
+    error UnauthorizedWitness();
 
 }

--- a/src/libraries/Errors.sol
+++ b/src/libraries/Errors.sol
@@ -312,61 +312,70 @@ library Errors {
     error InsufficientBalance();
 
     /* -------------------------------------------------------------------------- */
-    /*                          ExocoreBtcGateway Errors                          */
+    /*                          UTXOGateway Errors                          */
     /* -------------------------------------------------------------------------- */
 
-    /// @dev ExocoreBtcGateway: witness has already submitted proof
+    /// @dev UTXOGateway: witness has already submitted proof
     error WitnessAlreadySubmittedProof();
 
-    /// @dev ExocoreBtcGateway: invalid stake message
+    /// @dev UTXOGateway: invalid stake message
     error InvalidStakeMessage();
 
-    /// @dev ExocoreBtcGateway: transaction tag has already been processed
+    /// @dev UTXOGateway: transaction tag has already been processed
     error TxTagAlreadyProcessed();
 
-    /// @dev ExocoreBtcGateway: invalid operator address
+    /// @dev UTXOGateway: invalid operator address
     error InvalidOperator();
 
-    /// @dev ExocoreBtcGateway: invalid token
+    /// @dev UTXOGateway: invalid token
     error InvalidToken();
 
-    /// @dev ExocoreBtcGateway: witness has already been authorized
+    /// @dev UTXOGateway: witness has already been authorized
     error WitnessAlreadyAuthorized(address witness);
 
-    /// @dev ExocoreBtcGateway: witness has not been authorized
+    /// @dev UTXOGateway: witness has not been authorized
     error WitnessNotAuthorized(address witness);
 
-    /// @dev ExocoreBtcGateway: cannot remove the last witness
+    /// @dev UTXOGateway: cannot remove the last witness
     error CannotRemoveLastWitness();
 
-    /// @dev ExocoreBtcGateway: invalid client chain
+    /// @dev UTXOGateway: invalid client chain
     error InvalidClientChain();
 
-    /// @dev ExocoreBtcGateway: deposit failed
+    /// @dev UTXOGateway: deposit failed
     error DepositFailed(bytes txTag);
 
-    /// @dev ExocoreBtcGateway: address not registered
+    /// @dev UTXOGateway: address not registered
     error AddressNotRegistered();
 
-    /// @dev ExocoreBtcGateway: delegation failed
+    /// @dev UTXOGateway: delegation failed
     error DelegationFailed();
 
-    /// @dev ExocoreBtcGateway: withdraw principal failed
+    /// @dev UTXOGateway: withdraw principal failed
     error WithdrawPrincipalFailed();
 
-    /// @dev ExocoreBtcGateway: undelegation failed
+    /// @dev UTXOGateway: undelegation failed
     error UndelegationFailed();
 
-    /// @dev ExocoreBtcGateway: withdraw reward failed
+    /// @dev UTXOGateway: withdraw reward failed
     error WithdrawRewardFailed();
 
-    /// @dev ExocoreBtcGateway: request not found
+    /// @dev UTXOGateway: request not found
     error RequestNotFound(uint64 requestId);
 
-    /// @dev ExocoreBtcGateway: request already exists
+    /// @dev UTXOGateway: request already exists
     error RequestAlreadyExists(uint32 clientChain, uint64 requestId);
 
-    /// @dev ExocoreBtcGateway: witness not authorized
+    /// @dev UTXOGateway: witness not authorized
     error UnauthorizedWitness();
+
+    /// @dev UTXOGateway: consensus is not activated
+    error ConsensusNotRequired();
+
+    /// @dev UTXOGateway: consensus is required
+    error ConsensusRequired();
+
+    /// @dev UTXOGateway: invalid required proofs
+    error InvalidRequiredProofs();
 
 }

--- a/src/libraries/Errors.sol
+++ b/src/libraries/Errors.sol
@@ -311,4 +311,11 @@ library Errors {
     /// @dev RewardVault: insufficient balance
     error InsufficientBalance();
 
+    /* -------------------------------------------------------------------------- */
+    /*                          ExocoreBtcGateway Errors                          */
+    /* -------------------------------------------------------------------------- */
+
+    /// @dev ExocoreBtcGateway: witness has already submitted proof
+    error WitnessAlreadySubmittedProof();
+
 }

--- a/src/libraries/ExocoreBytes.sol
+++ b/src/libraries/ExocoreBytes.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+library ExocoreBytes {
+    /// @notice Converts an Ethereum address to Exocore's 32-byte address format
+    /// @param addr The Ethereum address to convert
+    /// @return The address as 32-byte Exocore format (20 bytes + right padding)
+    function toExocoreBytes(address addr) internal pure returns (bytes memory) {
+        return abi.encodePacked(bytes32(bytes20(addr)));
+    }
+}

--- a/src/libraries/ExocoreBytes.sol
+++ b/src/libraries/ExocoreBytes.sol
@@ -2,10 +2,12 @@
 pragma solidity ^0.8.0;
 
 library ExocoreBytes {
+
     /// @notice Converts an Ethereum address to Exocore's 32-byte address format
     /// @param addr The Ethereum address to convert
     /// @return The address as 32-byte Exocore format (20 bytes + right padding)
     function toExocoreBytes(address addr) internal pure returns (bytes memory) {
         return abi.encodePacked(bytes32(bytes20(addr)));
     }
+
 }

--- a/src/storage/ExocoreBtcGatewayStorage.sol
+++ b/src/storage/ExocoreBtcGatewayStorage.sol
@@ -192,6 +192,22 @@ contract ExocoreBtcGatewayStorage {
     uint256[40] private __gap;
 
     // Events
+
+    /**
+     * @dev Emitted when a stake message is executed
+     * @param chainId The LayerZero chain ID of the client chain
+     * @param nonce The nonce of the stake message
+     * @param exocoreAddress The Exocore address of the depositor
+     * @param amount The amount deposited(delegated)
+     */
+    event StakeMsgExecuted(ClientChainID indexed chainId, uint64 nonce, address indexed exocoreAddress, uint256 amount);
+
+    /**
+     * @dev Emitted when a transaction is processed
+     * @param txId The hash of the stake message
+     */
+    event TransactionProcessed(bytes32 indexed txId);
+
     /**
      * @dev Emitted when a deposit is completed
      * @param srcChainId The source chain ID
@@ -339,9 +355,8 @@ contract ExocoreBtcGatewayStorage {
      * @dev Emitted when a proof is submitted
      * @param messageHash The hash of the stake message
      * @param witness The address of the witness submitting the proof
-     * @param message The stake message associated with the proof
      */
-    event ProofSubmitted(bytes32 indexed messageHash, address indexed witness, StakeMsg message);
+    event ProofSubmitted(bytes32 indexed messageHash, address indexed witness);
 
     /**
      * @dev Emitted when a deposit is processed
@@ -411,97 +426,6 @@ contract ExocoreBtcGatewayStorage {
     /// @param clientChainId The LayerZero chain ID of the client chain.
     /// @param token The address of the token.
     event WhitelistTokenUpdated(uint32 clientChainId, address indexed token);
-
-    // Errors
-    /**
-     * @dev Thrown when an unauthorized witness attempts an action
-     */
-    error UnauthorizedWitness();
-
-    /**
-     * @dev Thrown when registering a client chain to Exocore fails
-     * @param clientChainId The ID of the client chain that failed to register
-     */
-    error RegisterClientChainToExocoreFailed(uint32 clientChainId);
-
-    /**
-     * @dev Thrown when a zero address is provided where it's not allowed
-     */
-    error ZeroAddressNotAllowed();
-
-    /**
-     * @dev Thrown when attempting to process a Bitcoin transaction that has already been processed
-     */
-    error BtcTxAlreadyProcessed();
-
-    /**
-     * @dev Thrown when an address is not registered
-     */
-    error AddressNotRegistered();
-
-    /**
-     * @dev Thrown when trying to process a request with an invalid status
-     * @param requestId The ID of the request with the invalid status
-     */
-    error InvalidRequestStatus(bytes32 requestId);
-
-    /**
-     * @dev Thrown when the requested peg-out does not exist
-     * @param requestId The ID of the non-existent request
-     */
-    error RequestNotFound(uint64 requestId);
-
-    /**
-     * @dev Thrown when attempting to create a request that already exists
-     * @param requestId The ID of the existing request
-     */
-    error RequestAlreadyExists(uint64 requestId);
-
-    /**
-     * @dev Thrown when a deposit operation fails
-     * @param btcTxTag The Bitcoin transaction tag of the failed deposit
-     */
-    error DepositFailed(bytes btcTxTag);
-
-    /**
-     * @dev Thrown when a principal withdrawal operation fails
-     */
-    error WithdrawPrincipalFailed();
-
-    /**
-     * @dev Thrown when a reward withdrawal operation fails
-     */
-    error WithdrawRewardFailed();
-
-    /**
-     * @dev Thrown when a delegation operation fails, not when processing a stake message
-     */
-    error DelegationFailed();
-
-    /**
-     * @dev Thrown when an undelegation operation fails
-     */
-    error UndelegationFailed();
-
-    /**
-     * @dev Thrown when an Ether transfer fails
-     */
-    error EtherTransferFailed();
-
-    /**
-     * @dev Thrown when an invalid signature is provided
-     */
-    error InvalidSignature();
-
-    /**
-     * @dev Thrown when an unexpected inbound nonce is encountered
-     * @param expectedNonce The expected nonce
-     * @param actualNonce The actual nonce received
-     */
-    error UnexpectedInboundNonce(uint64 expectedNonce, uint64 actualNonce);
-
-    error InvalidTokenType();
-    error InvalidClientChainId();
 
     /**
      * @dev Modifier to check if an amount is valid

--- a/src/storage/ExocoreBtcGatewayStorage.sol
+++ b/src/storage/ExocoreBtcGatewayStorage.sol
@@ -8,6 +8,13 @@ pragma solidity ^0.8.19;
 contract ExocoreBtcGatewayStorage {
 
     /**
+     * @notice Enum to represent the type of supported token
+     */
+    enum TokenType {
+        BTC
+    }
+
+    /**
      * @dev Enum to represent the status of a transaction
      */
     enum TxStatus {
@@ -84,6 +91,18 @@ contract ExocoreBtcGatewayStorage {
     }
 
     // Constants
+    uint32 public constant BITCOIN_CHAIN_ID = 1;
+    uint8 public constant BITCOIN_STAKER_ACCOUNT_LENGTH = 20;
+    string public constant BITCOIN_NAME = "Bitcoin";
+    string public constant BITCOIN_METADATA = "Bitcoin";
+    string public constant BITCOIN_SIGNATURE_SCHEME = "ECDSA";
+    address public constant VIRTUAL_BTC_ADDRESS = 0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB;
+    bytes public constant VIRTUAL_BTC_TOKEN = abi.encodePacked(bytes32(bytes20(VIRTUAL_BTC_ADDRESS)));
+    uint8 public constant BTC_DECIMALS = 8;
+    string public constant BTC_NAME = "BTC";
+    string public constant BTC_METADATA = "BTC";
+    string public constant BTC_ORACLE_INFO = "BTC,BITCOIN,8";
+
     address public constant EXOCORE_WITNESS = address(0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266);
     uint256 public constant REQUIRED_PROOFS = 2;
     uint256 public constant PROOF_TIMEOUT = 1 days;
@@ -134,6 +153,8 @@ contract ExocoreBtcGatewayStorage {
      * @dev Mapping to store inbound bytes nonce for each chain and sender
      */
     mapping(uint32 => mapping(bytes => uint64)) public inboundBytesNonce;
+
+    uint256[40] private __gap;
 
     // Events
     /**
@@ -341,6 +362,24 @@ contract ExocoreBtcGatewayStorage {
      */
     event PegOutRequestStatusUpdated(bytes32 indexed requestId, TxStatus newStatus);
 
+    /// @notice Emitted upon the registration of a new client chain.
+    /// @param clientChainId The LayerZero chain ID of the client chain.
+    event ClientChainRegistered(uint32 clientChainId);
+
+    /// @notice Emitted upon the update of a client chain.
+    /// @param clientChainId The LayerZero chain ID of the client chain.
+    event ClientChainUpdated(uint32 clientChainId);
+
+    /// @notice Emitted when a token is added to the whitelist.
+    /// @param clientChainId The LayerZero chain ID of the client chain.
+    /// @param token The address of the token.
+    event WhitelistTokenAdded(uint32 clientChainId, bytes32 token);
+
+    /// @notice Emitted when a token is updated in the whitelist.
+    /// @param clientChainId The LayerZero chain ID of the client chain.
+    /// @param token The address of the token.
+    event WhitelistTokenUpdated(uint32 clientChainId, bytes32 token);
+
     // Errors
     /**
      * @dev Thrown when an unauthorized witness attempts an action
@@ -429,6 +468,8 @@ contract ExocoreBtcGatewayStorage {
      */
     error UnexpectedInboundNonce(uint64 expectedNonce, uint64 actualNonce);
 
+    error InvalidTokenType();
+
     /**
      * @dev Modifier to check if a token is whitelisted
      * @param token The address of the token to check
@@ -461,6 +502,12 @@ contract ExocoreBtcGatewayStorage {
         inboundBytesNonce[srcChainId][srcAddress] = nonce;
     }
 
-    uint256[40] private __gap;
+    function getTokenByType(TokenType _tokenType) public pure returns (bytes memory) {
+        if (_tokenType == TokenType.BTC) {
+            return VIRTUAL_BTC_TOKEN;
+        } else {
+            revert InvalidTokenType();
+        }   
+    }
 
 }

--- a/src/storage/UTXOGatewayStorage.sol
+++ b/src/storage/UTXOGatewayStorage.sol
@@ -216,12 +216,14 @@ contract UTXOGatewayStorage {
 
     /**
      * @dev Emitted when a stake message is executed
-     * @param chainId The chain ID of the client chain, should not violate the layerzero chain id
+     * @param clientChainId The chain ID of the client chain, should not violate the layerzero chain id
      * @param nonce The nonce of the stake message
      * @param exocoreAddress The Exocore address of the depositor
      * @param amount The amount deposited(delegated)
      */
-    event StakeMsgExecuted(ClientChainID indexed chainId, uint64 nonce, address indexed exocoreAddress, uint256 amount);
+    event StakeMsgExecuted(
+        ClientChainID indexed clientChainId, uint64 nonce, address indexed exocoreAddress, uint256 amount
+    );
 
     /**
      * @dev Emitted when a transaction is processed
@@ -231,7 +233,7 @@ contract UTXOGatewayStorage {
 
     /**
      * @dev Emitted when a deposit is completed
-     * @param srcChainId The source chain ID
+     * @param clientChainId The client chain ID
      * @param txTag The txid + vout-index
      * @param depositorExoAddr The depositor's Exocore address
      * @param depositorClientChainAddr The depositor's client chain address
@@ -239,7 +241,7 @@ contract UTXOGatewayStorage {
      * @param updatedBalance The updated balance after deposit
      */
     event DepositCompleted(
-        ClientChainID indexed srcChainId,
+        ClientChainID indexed clientChainId,
         bytes txTag,
         address indexed depositorExoAddr,
         bytes depositorClientChainAddr,
@@ -250,14 +252,14 @@ contract UTXOGatewayStorage {
     /**
      * @dev Emitted when a principal withdrawal is requested
      * @param requestId The unique identifier for the withdrawal request
-     * @param srcChainId The source chain ID
+     * @param clientChainId The client chain ID
      * @param withdrawerExoAddr The withdrawer's Exocore address
      * @param withdrawerClientChainAddr The withdrawer's client chain address
      * @param amount The amount to withdraw
      * @param updatedBalance The updated balance after withdrawal request
      */
     event WithdrawPrincipalRequested(
-        ClientChainID indexed srcChainId,
+        ClientChainID indexed clientChainId,
         uint64 indexed requestId,
         address indexed withdrawerExoAddr,
         bytes withdrawerClientChainAddr,
@@ -268,14 +270,14 @@ contract UTXOGatewayStorage {
     /**
      * @dev Emitted when a reward withdrawal is requested
      * @param requestId The unique identifier for the withdrawal request
-     * @param srcChainId The source chain ID
+     * @param clientChainId The client chain ID
      * @param withdrawerExoAddr The withdrawer's Exocore address
      * @param withdrawerClientChainAddr The withdrawer's client chain address
      * @param amount The amount to withdraw
      * @param updatedBalance The updated balance after withdrawal request
      */
     event WithdrawRewardRequested(
-        ClientChainID indexed srcChainId,
+        ClientChainID indexed clientChainId,
         uint64 indexed requestId,
         address indexed withdrawerExoAddr,
         bytes withdrawerClientChainAddr,
@@ -285,7 +287,7 @@ contract UTXOGatewayStorage {
 
     /**
      * @dev Emitted when a principal withdrawal is completed
-     * @param srcChainId The source chain ID
+     * @param clientChainId The client chain ID
      * @param requestId The unique identifier for the withdrawal request
      * @param withdrawerExoAddr The withdrawer's Exocore address
      * @param withdrawerClientChainAddr The withdrawer's client chain address
@@ -293,7 +295,7 @@ contract UTXOGatewayStorage {
      * @param updatedBalance The updated balance after withdrawal
      */
     event WithdrawPrincipalCompleted(
-        ClientChainID indexed srcChainId,
+        ClientChainID indexed clientChainId,
         bytes32 indexed requestId,
         address indexed withdrawerExoAddr,
         bytes withdrawerClientChainAddr,
@@ -303,7 +305,7 @@ contract UTXOGatewayStorage {
 
     /**
      * @dev Emitted when a reward withdrawal is completed
-     * @param srcChainId The source chain ID
+     * @param clientChainId The client chain ID
      * @param requestId The unique identifier for the withdrawal request
      * @param withdrawerExoAddr The withdrawer's Exocore address
      * @param withdrawerClientChainAddr The withdrawer's client chain address
@@ -311,7 +313,7 @@ contract UTXOGatewayStorage {
      * @param updatedBalance The updated balance after withdrawal
      */
     event WithdrawRewardCompleted(
-        ClientChainID indexed srcChainId,
+        ClientChainID indexed clientChainId,
         bytes32 indexed requestId,
         address indexed withdrawerExoAddr,
         bytes withdrawerClientChainAddr,
@@ -354,11 +356,11 @@ contract UTXOGatewayStorage {
 
     /**
      * @dev Emitted when an address is registered
-     * @param chainId The chain ID of the client chain, should not violate the layerzero chain id
+     * @param clientChainId The client chain ID
      * @param depositor The depositor's address
      * @param exocoreAddress The corresponding Exocore address
      */
-    event AddressRegistered(ClientChainID indexed chainId, bytes depositor, address indexed exocoreAddress);
+    event AddressRegistered(ClientChainID indexed clientChainId, bytes depositor, address indexed exocoreAddress);
 
     /**
      * @dev Emitted when a new witness is added

--- a/src/storage/UTXOGatewayStorage.sol
+++ b/src/storage/UTXOGatewayStorage.sol
@@ -49,16 +49,23 @@ contract UTXOGatewayStorage {
     }
 
     /**
-     * @dev Struct to store interchain message information
+     * @dev Struct to store stake message information
+     * @param clientChainId The client chain ID
+     * @param clientAddress The client chain address
+     * @param exocoreAddress The Exocore address
+     * @param operator The operator
+     * @param amount The amount
+     * @param nonce The nonce
+     * @param txTag The tx tag
      */
     struct StakeMsg {
-        ClientChainID chainId;
-        bytes srcAddress; // the address of the depositor on the source chain
-        address exocoreAddress; // the address of the depositor on the Exocore chain
-        string operator; // the operator to delegate to, would only deposit to exocore address if operator is empty
-        uint256 amount; // deposit amount
+        ClientChainID clientChainId;
+        bytes clientAddress;
+        address exocoreAddress;
+        string operator;
+        uint256 amount;
         uint64 nonce;
-        bytes txTag; // lowercase(txid-vout)
+        bytes txTag;
     }
 
     /**
@@ -86,10 +93,10 @@ contract UTXOGatewayStorage {
      * @dev Struct for peg-out requests
      */
     struct PegOutRequest {
-        ClientChainID chainId;
+        ClientChainID clientChainId;
         uint64 nonce;
         address requester;
-        bytes clientChainAddress;
+        bytes clientAddress;
         uint256 amount;
         WithdrawType withdrawType;
     }
@@ -431,21 +438,21 @@ contract UTXOGatewayStorage {
 
     /// @notice Emitted upon the registration of a new client chain.
     /// @param clientChainId The chain ID of the client chain.
-    event ClientChainRegistered(uint32 clientChainId);
+    event ClientChainRegistered(ClientChainID clientChainId);
 
     /// @notice Emitted upon the update of a client chain.
     /// @param clientChainId The chain ID of the client chain.
-    event ClientChainUpdated(uint32 clientChainId);
+    event ClientChainUpdated(ClientChainID clientChainId);
 
     /// @notice Emitted when a token is added to the whitelist.
     /// @param clientChainId The chain ID of the client chain.
     /// @param token The address of the token.
-    event WhitelistTokenAdded(uint32 clientChainId, address indexed token);
+    event WhitelistTokenAdded(ClientChainID clientChainId, address indexed token);
 
     /// @notice Emitted when a token is updated in the whitelist.
     /// @param clientChainId The chain ID of the client chain.
     /// @param token The address of the token.
-    event WhitelistTokenUpdated(uint32 clientChainId, address indexed token);
+    event WhitelistTokenUpdated(ClientChainID clientChainId, address indexed token);
 
     /// @notice Emitted when consensus is activated
     /// @param requiredWitnessesCount The number of required witnesses

--- a/test/foundry/unit/UTXOGateway.t.sol
+++ b/test/foundry/unit/UTXOGateway.t.sol
@@ -84,10 +84,10 @@ contract UTXOGatewayTest is Test {
     event StakeMsgExecuted(bytes32 indexed txId);
     event BridgeFeeRateUpdated(uint256 newRate);
 
-    event ClientChainRegistered(uint32 clientChainId);
-    event ClientChainUpdated(uint32 clientChainId);
-    event WhitelistTokenAdded(uint32 clientChainId, address indexed token);
-    event WhitelistTokenUpdated(uint32 clientChainId, address indexed token);
+    event ClientChainRegistered(UTXOGatewayStorage.ClientChainID clientChainId);
+    event ClientChainUpdated(UTXOGatewayStorage.ClientChainID clientChainId);
+    event WhitelistTokenAdded(UTXOGatewayStorage.ClientChainID clientChainId, address indexed token);
+    event WhitelistTokenUpdated(UTXOGatewayStorage.ClientChainID clientChainId, address indexed token);
     event DelegationFailedForStake(
         UTXOGatewayStorage.ClientChainID indexed clientChainId,
         address indexed exoDelegator,
@@ -477,9 +477,9 @@ contract UTXOGatewayTest is Test {
         );
 
         vm.expectEmit(true, false, false, false);
-        emit ClientChainRegistered(uint32(uint8(UTXOGatewayStorage.ClientChainID.Bitcoin)));
+        emit ClientChainRegistered(UTXOGatewayStorage.ClientChainID.Bitcoin);
         vm.expectEmit(true, false, false, false);
-        emit WhitelistTokenAdded(uint32(uint8(UTXOGatewayStorage.ClientChainID.Bitcoin)), VIRTUAL_TOKEN_ADDRESS);
+        emit WhitelistTokenAdded(UTXOGatewayStorage.ClientChainID.Bitcoin, VIRTUAL_TOKEN_ADDRESS);
 
         gateway.activateStakingForClientChain(UTXOGatewayStorage.ClientChainID.Bitcoin);
         vm.stopPrank();
@@ -533,9 +533,9 @@ contract UTXOGatewayTest is Test {
         );
 
         vm.expectEmit(true, false, false, false);
-        emit ClientChainUpdated(uint32(uint8(UTXOGatewayStorage.ClientChainID.Bitcoin)));
+        emit ClientChainUpdated(UTXOGatewayStorage.ClientChainID.Bitcoin);
         vm.expectEmit(true, false, false, false);
-        emit WhitelistTokenUpdated(uint32(uint8(UTXOGatewayStorage.ClientChainID.Bitcoin)), VIRTUAL_TOKEN_ADDRESS);
+        emit WhitelistTokenUpdated(UTXOGatewayStorage.ClientChainID.Bitcoin, VIRTUAL_TOKEN_ADDRESS);
 
         gateway.activateStakingForClientChain(UTXOGatewayStorage.ClientChainID.Bitcoin);
         vm.stopPrank();
@@ -642,8 +642,8 @@ contract UTXOGatewayTest is Test {
 
         // Create stake message
         UTXOGatewayStorage.StakeMsg memory stakeMsg = UTXOGatewayStorage.StakeMsg({
-            chainId: UTXOGatewayStorage.ClientChainID.Bitcoin,
-            srcAddress: btcAddress,
+            clientChainId: UTXOGatewayStorage.ClientChainID.Bitcoin,
+            clientAddress: btcAddress,
             exocoreAddress: user,
             operator: operator,
             amount: 1 ether,
@@ -681,13 +681,13 @@ contract UTXOGatewayTest is Test {
         signature = _generateSignature(stakeMsg, witnesses[2].privateKey);
         vm.prank(relayer);
         vm.expectEmit(true, false, false, false);
-        emit StakeMsgExecuted(stakeMsg.chainId, stakeMsg.nonce, stakeMsg.exocoreAddress, stakeMsg.amount);
+        emit StakeMsgExecuted(stakeMsg.clientChainId, stakeMsg.nonce, stakeMsg.exocoreAddress, stakeMsg.amount);
         vm.expectEmit(true, false, false, false);
         emit TransactionProcessed(txId);
         gateway.submitProofForStakeMsg(witnesses[2].addr, stakeMsg, signature);
 
         // Verify message was processed
-        assertTrue(gateway.processedClientChainTxs(stakeMsg.chainId, stakeMsg.txTag));
+        assertTrue(gateway.processedClientChainTxs(stakeMsg.clientChainId, stakeMsg.txTag));
         assertTrue(gateway.processedTransactions(txId));
     }
 
@@ -698,8 +698,8 @@ contract UTXOGatewayTest is Test {
         _deactivateConsensus();
 
         UTXOGatewayStorage.StakeMsg memory stakeMsg = UTXOGatewayStorage.StakeMsg({
-            chainId: UTXOGatewayStorage.ClientChainID.Bitcoin,
-            srcAddress: btcAddress,
+            clientChainId: UTXOGatewayStorage.ClientChainID.Bitcoin,
+            clientAddress: btcAddress,
             exocoreAddress: user,
             operator: operator,
             amount: 1 ether,
@@ -720,8 +720,8 @@ contract UTXOGatewayTest is Test {
         _activateConsensus();
 
         UTXOGatewayStorage.StakeMsg memory stakeMsg = UTXOGatewayStorage.StakeMsg({
-            chainId: UTXOGatewayStorage.ClientChainID.Bitcoin,
-            srcAddress: btcAddress,
+            clientChainId: UTXOGatewayStorage.ClientChainID.Bitcoin,
+            clientAddress: btcAddress,
             exocoreAddress: user,
             operator: operator,
             amount: 1 ether,
@@ -741,8 +741,8 @@ contract UTXOGatewayTest is Test {
         _activateConsensus();
 
         UTXOGatewayStorage.StakeMsg memory stakeMsg = UTXOGatewayStorage.StakeMsg({
-            chainId: UTXOGatewayStorage.ClientChainID.Bitcoin,
-            srcAddress: btcAddress,
+            clientChainId: UTXOGatewayStorage.ClientChainID.Bitcoin,
+            clientAddress: btcAddress,
             exocoreAddress: user,
             operator: operator,
             amount: 1 ether,
@@ -763,8 +763,8 @@ contract UTXOGatewayTest is Test {
         _activateConsensus();
 
         UTXOGatewayStorage.StakeMsg memory stakeMsg = UTXOGatewayStorage.StakeMsg({
-            chainId: UTXOGatewayStorage.ClientChainID.Bitcoin,
-            srcAddress: btcAddress,
+            clientChainId: UTXOGatewayStorage.ClientChainID.Bitcoin,
+            clientAddress: btcAddress,
             exocoreAddress: user,
             operator: operator,
             amount: 1 ether,
@@ -791,7 +791,7 @@ contract UTXOGatewayTest is Test {
         bytes32 messageHash = _getMessageHash(stakeMsg);
         assertEq(uint8(gateway.getTransactionStatus(messageHash)), uint8(UTXOGatewayStorage.TxStatus.Pending));
         assertEq(gateway.getTransactionProofCount(messageHash), 1);
-        assertFalse(gateway.processedClientChainTxs(stakeMsg.chainId, stakeMsg.txTag));
+        assertFalse(gateway.processedClientChainTxs(stakeMsg.clientChainId, stakeMsg.txTag));
     }
 
     function test_SubmitProofForStakeMsg_RestartExpiredTransaction() public {
@@ -799,8 +799,8 @@ contract UTXOGatewayTest is Test {
         _activateConsensus();
 
         UTXOGatewayStorage.StakeMsg memory stakeMsg = UTXOGatewayStorage.StakeMsg({
-            chainId: UTXOGatewayStorage.ClientChainID.Bitcoin,
-            srcAddress: btcAddress,
+            clientChainId: UTXOGatewayStorage.ClientChainID.Bitcoin,
+            clientAddress: btcAddress,
             exocoreAddress: user,
             operator: operator,
             amount: 1 ether,
@@ -837,8 +837,8 @@ contract UTXOGatewayTest is Test {
         assertEq(gateway.requiredProofs(), 3);
 
         UTXOGatewayStorage.StakeMsg memory stakeMsg = UTXOGatewayStorage.StakeMsg({
-            chainId: UTXOGatewayStorage.ClientChainID.Bitcoin,
-            srcAddress: btcAddress,
+            clientChainId: UTXOGatewayStorage.ClientChainID.Bitcoin,
+            clientAddress: btcAddress,
             exocoreAddress: user,
             operator: operator,
             amount: 1 ether,
@@ -871,7 +871,7 @@ contract UTXOGatewayTest is Test {
         assertEq(uint8(gateway.getTransactionStatus(messageHash)), uint8(UTXOGatewayStorage.TxStatus.Pending));
         assertEq(gateway.getTransactionProofCount(messageHash), 2);
         assertFalse(gateway.processedTransactions(messageHash));
-        assertFalse(gateway.processedClientChainTxs(stakeMsg.chainId, stakeMsg.txTag));
+        assertFalse(gateway.processedClientChainTxs(stakeMsg.clientChainId, stakeMsg.txTag));
         assertTrue(gateway.getTransactionWitnessTime(messageHash, witnesses[0].addr) > 0);
         assertTrue(gateway.getTransactionWitnessTime(messageHash, witnesses[1].addr) > 0);
     }
@@ -881,8 +881,8 @@ contract UTXOGatewayTest is Test {
         _activateConsensus();
 
         UTXOGatewayStorage.StakeMsg memory stakeMsg = UTXOGatewayStorage.StakeMsg({
-            chainId: UTXOGatewayStorage.ClientChainID.Bitcoin,
-            srcAddress: btcAddress,
+            clientChainId: UTXOGatewayStorage.ClientChainID.Bitcoin,
+            clientAddress: btcAddress,
             exocoreAddress: user,
             operator: operator,
             amount: 1 ether,
@@ -906,8 +906,8 @@ contract UTXOGatewayTest is Test {
         _activateConsensus();
 
         UTXOGatewayStorage.StakeMsg memory stakeMsg = UTXOGatewayStorage.StakeMsg({
-            chainId: UTXOGatewayStorage.ClientChainID.Bitcoin,
-            srcAddress: btcAddress,
+            clientChainId: UTXOGatewayStorage.ClientChainID.Bitcoin,
+            clientAddress: btcAddress,
             exocoreAddress: user,
             operator: operator,
             amount: 1 ether,
@@ -926,8 +926,8 @@ contract UTXOGatewayTest is Test {
         _deactivateConsensus();
 
         UTXOGatewayStorage.StakeMsg memory stakeMsg = UTXOGatewayStorage.StakeMsg({
-            chainId: UTXOGatewayStorage.ClientChainID.Bitcoin,
-            srcAddress: btcAddress,
+            clientChainId: UTXOGatewayStorage.ClientChainID.Bitcoin,
+            clientAddress: btcAddress,
             exocoreAddress: user,
             operator: "",
             amount: 1 ether,
@@ -955,7 +955,7 @@ contract UTXOGatewayTest is Test {
         gateway.processStakeMessage(witnesses[0].addr, stakeMsg, signature);
 
         // Verify address registration
-        assertEq(gateway.getClientChainAddress(UTXOGatewayStorage.ClientChainID.Bitcoin, user), btcAddress);
+        assertEq(gateway.getClientAddress(UTXOGatewayStorage.ClientChainID.Bitcoin, user), btcAddress);
         assertEq(gateway.getExocoreAddress(UTXOGatewayStorage.ClientChainID.Bitcoin, btcAddress), user);
     }
 
@@ -963,8 +963,8 @@ contract UTXOGatewayTest is Test {
         _deactivateConsensus();
 
         UTXOGatewayStorage.StakeMsg memory stakeMsg = UTXOGatewayStorage.StakeMsg({
-            chainId: UTXOGatewayStorage.ClientChainID.Bitcoin,
-            srcAddress: btcAddress,
+            clientChainId: UTXOGatewayStorage.ClientChainID.Bitcoin,
+            clientAddress: btcAddress,
             exocoreAddress: user,
             operator: operator,
             amount: 1 ether,
@@ -995,7 +995,7 @@ contract UTXOGatewayTest is Test {
             UTXOGatewayStorage.ClientChainID.Bitcoin,
             stakeMsg.txTag,
             user,
-            stakeMsg.srcAddress,
+            stakeMsg.clientAddress,
             amountAfterFee,
             amountAfterFee
         );
@@ -1011,8 +1011,8 @@ contract UTXOGatewayTest is Test {
         _deactivateConsensus();
 
         UTXOGatewayStorage.StakeMsg memory stakeMsg = UTXOGatewayStorage.StakeMsg({
-            chainId: UTXOGatewayStorage.ClientChainID.Bitcoin,
-            srcAddress: btcAddress,
+            clientChainId: UTXOGatewayStorage.ClientChainID.Bitcoin,
+            clientAddress: btcAddress,
             exocoreAddress: user,
             operator: operator,
             amount: 1 ether,
@@ -1040,8 +1040,8 @@ contract UTXOGatewayTest is Test {
 
     function test_ProcessStakeMessage_DelegationFailureNotRevert() public {
         UTXOGatewayStorage.StakeMsg memory stakeMsg = UTXOGatewayStorage.StakeMsg({
-            chainId: UTXOGatewayStorage.ClientChainID.Bitcoin,
-            srcAddress: btcAddress,
+            clientChainId: UTXOGatewayStorage.ClientChainID.Bitcoin,
+            clientAddress: btcAddress,
             exocoreAddress: user,
             operator: operator,
             amount: 1 ether,
@@ -1068,7 +1068,7 @@ contract UTXOGatewayTest is Test {
             UTXOGatewayStorage.ClientChainID.Bitcoin,
             stakeMsg.txTag,
             user,
-            stakeMsg.srcAddress,
+            stakeMsg.clientAddress,
             1 ether,
             stakeMsg.amount
         );
@@ -1084,8 +1084,8 @@ contract UTXOGatewayTest is Test {
         _deactivateConsensus();
 
         UTXOGatewayStorage.StakeMsg memory stakeMsg = UTXOGatewayStorage.StakeMsg({
-            chainId: UTXOGatewayStorage.ClientChainID.Bitcoin,
-            srcAddress: btcAddress,
+            clientChainId: UTXOGatewayStorage.ClientChainID.Bitcoin,
+            clientAddress: btcAddress,
             exocoreAddress: user,
             operator: "",
             amount: 1 ether,
@@ -1109,8 +1109,8 @@ contract UTXOGatewayTest is Test {
         _deactivateConsensus();
 
         UTXOGatewayStorage.StakeMsg memory stakeMsg = UTXOGatewayStorage.StakeMsg({
-            chainId: UTXOGatewayStorage.ClientChainID.Bitcoin,
-            srcAddress: btcAddress,
+            clientChainId: UTXOGatewayStorage.ClientChainID.Bitcoin,
+            clientAddress: btcAddress,
             exocoreAddress: user,
             operator: "",
             amount: 1 ether,
@@ -1132,8 +1132,8 @@ contract UTXOGatewayTest is Test {
         _deactivateConsensus();
 
         UTXOGatewayStorage.StakeMsg memory stakeMsg = UTXOGatewayStorage.StakeMsg({
-            chainId: UTXOGatewayStorage.ClientChainID.Bitcoin,
-            srcAddress: btcAddress,
+            clientChainId: UTXOGatewayStorage.ClientChainID.Bitcoin,
+            clientAddress: btcAddress,
             exocoreAddress: user,
             operator: "",
             amount: 1 ether,
@@ -1154,8 +1154,8 @@ contract UTXOGatewayTest is Test {
 
         // Create invalid message with all zero values
         UTXOGatewayStorage.StakeMsg memory stakeMsg = UTXOGatewayStorage.StakeMsg({
-            chainId: UTXOGatewayStorage.ClientChainID.None,
-            srcAddress: bytes(""),
+            clientChainId: UTXOGatewayStorage.ClientChainID.None,
+            clientAddress: bytes(""),
             exocoreAddress: address(0),
             operator: "",
             amount: 0,
@@ -1174,8 +1174,8 @@ contract UTXOGatewayTest is Test {
         _deactivateConsensus();
 
         UTXOGatewayStorage.StakeMsg memory stakeMsg = UTXOGatewayStorage.StakeMsg({
-            chainId: UTXOGatewayStorage.ClientChainID.Bitcoin,
-            srcAddress: btcAddress,
+            clientChainId: UTXOGatewayStorage.ClientChainID.Bitcoin,
+            clientAddress: btcAddress,
             exocoreAddress: address(0), // Zero address
             operator: "",
             amount: 1 ether,
@@ -1194,8 +1194,8 @@ contract UTXOGatewayTest is Test {
         _deactivateConsensus();
 
         UTXOGatewayStorage.StakeMsg memory stakeMsg = UTXOGatewayStorage.StakeMsg({
-            chainId: UTXOGatewayStorage.ClientChainID.Bitcoin,
-            srcAddress: btcAddress,
+            clientChainId: UTXOGatewayStorage.ClientChainID.Bitcoin,
+            clientAddress: btcAddress,
             exocoreAddress: user,
             operator: "",
             amount: 1 ether,
@@ -1208,7 +1208,7 @@ contract UTXOGatewayTest is Test {
         vm.prank(relayer);
         vm.expectRevert(
             abi.encodeWithSelector(
-                Errors.UnexpectedInboundNonce.selector, gateway.nextInboundNonce(stakeMsg.chainId), stakeMsg.nonce
+                Errors.UnexpectedInboundNonce.selector, gateway.nextInboundNonce(stakeMsg.clientChainId), stakeMsg.nonce
             )
         );
         gateway.processStakeMessage(witnesses[0].addr, stakeMsg, signature);
@@ -1432,10 +1432,10 @@ contract UTXOGatewayTest is Test {
         // Verify peg-out request details
         UTXOGatewayStorage.PegOutRequest memory request =
             gateway.getPegOutRequest(UTXOGatewayStorage.ClientChainID.Bitcoin, 1);
-        assertEq(uint8(request.chainId), uint8(UTXOGatewayStorage.ClientChainID.Bitcoin));
+        assertEq(uint8(request.clientChainId), uint8(UTXOGatewayStorage.ClientChainID.Bitcoin));
         assertEq(request.nonce, 1);
         assertEq(request.requester, user);
-        assertEq(request.clientChainAddress, btcAddress);
+        assertEq(request.clientAddress, btcAddress);
         assertEq(request.amount, 1 ether);
         assertEq(uint8(request.withdrawType), uint8(UTXOGatewayStorage.WithdrawType.WithdrawPrincipal));
     }
@@ -1520,10 +1520,10 @@ contract UTXOGatewayTest is Test {
         // Verify peg-out request details
         UTXOGatewayStorage.PegOutRequest memory request =
             gateway.getPegOutRequest(UTXOGatewayStorage.ClientChainID.Bitcoin, 1);
-        assertEq(uint8(request.chainId), uint8(UTXOGatewayStorage.ClientChainID.Bitcoin));
+        assertEq(uint8(request.clientChainId), uint8(UTXOGatewayStorage.ClientChainID.Bitcoin));
         assertEq(request.nonce, 1);
         assertEq(request.requester, user);
-        assertEq(request.clientChainAddress, btcAddress);
+        assertEq(request.clientAddress, btcAddress);
         assertEq(request.amount, 1 ether);
         assertEq(uint8(request.withdrawType), uint8(UTXOGatewayStorage.WithdrawType.WithdrawReward));
     }
@@ -1593,10 +1593,10 @@ contract UTXOGatewayTest is Test {
             gateway.processNextPegOut(UTXOGatewayStorage.ClientChainID.Bitcoin);
 
         // Verify returned request contents
-        assertEq(uint8(request.chainId), uint8(UTXOGatewayStorage.ClientChainID.Bitcoin));
+        assertEq(uint8(request.clientChainId), uint8(UTXOGatewayStorage.ClientChainID.Bitcoin));
         assertEq(request.nonce, 1);
         assertEq(request.requester, user);
-        assertEq(request.clientChainAddress, btcAddress);
+        assertEq(request.clientAddress, btcAddress);
         assertEq(request.amount, 1 ether);
         assertEq(uint8(request.withdrawType), uint8(UTXOGatewayStorage.WithdrawType.WithdrawPrincipal));
 
@@ -1605,7 +1605,7 @@ contract UTXOGatewayTest is Test {
             gateway.getPegOutRequest(UTXOGatewayStorage.ClientChainID.Bitcoin, 1);
         assertEq(deletedRequest.requester, address(0));
         assertEq(deletedRequest.amount, 0);
-        assertEq(deletedRequest.clientChainAddress, "");
+        assertEq(deletedRequest.clientAddress, "");
 
         // Verify outbound nonce increment
         assertEq(gateway.outboundNonce(UTXOGatewayStorage.ClientChainID.Bitcoin), 1);
@@ -1674,7 +1674,7 @@ contract UTXOGatewayTest is Test {
 
     // Helper function to setup a peg-out request
     function _setupPegOutRequest() internal {
-        if (gateway.getClientChainAddress(UTXOGatewayStorage.ClientChainID.Bitcoin, user).length == 0) {
+        if (gateway.getClientAddress(UTXOGatewayStorage.ClientChainID.Bitcoin, user).length == 0) {
             _mockRegisterAddress(user, btcAddress);
         }
 
@@ -1691,8 +1691,8 @@ contract UTXOGatewayTest is Test {
     // Helper functions
     function _mockRegisterAddress(address exocoreAddr, bytes memory btcAddr) internal {
         UTXOGatewayStorage.StakeMsg memory stakeMsg = UTXOGatewayStorage.StakeMsg({
-            chainId: UTXOGatewayStorage.ClientChainID.Bitcoin,
-            srcAddress: btcAddr,
+            clientChainId: UTXOGatewayStorage.ClientChainID.Bitcoin,
+            clientAddress: btcAddr,
             exocoreAddress: exocoreAddr,
             operator: "",
             amount: 1 ether,
@@ -1719,7 +1719,7 @@ contract UTXOGatewayTest is Test {
         gateway.processStakeMessage(witnesses[0].addr, stakeMsg, signature);
 
         // Verify address registration
-        assertEq(gateway.getClientChainAddress(UTXOGatewayStorage.ClientChainID.Bitcoin, exocoreAddr), btcAddr);
+        assertEq(gateway.getClientAddress(UTXOGatewayStorage.ClientChainID.Bitcoin, exocoreAddr), btcAddr);
         assertEq(gateway.getExocoreAddress(UTXOGatewayStorage.ClientChainID.Bitcoin, btcAddr), exocoreAddr);
     }
 
@@ -1735,8 +1735,8 @@ contract UTXOGatewayTest is Test {
     function _getMessageHash(UTXOGatewayStorage.StakeMsg memory msg_) internal pure returns (bytes32) {
         return keccak256(
             abi.encode(
-                msg_.chainId, // ClientChainID
-                msg_.srcAddress, // bytes - Bitcoin address
+                msg_.clientChainId, // ClientChainID
+                msg_.clientAddress, // bytes - Bitcoin address
                 msg_.exocoreAddress, // address
                 msg_.operator, // string
                 msg_.amount, // uint256


### PR DESCRIPTION
## Description

Since we need to work with multiple BTC like tokens like Doge, we need to refactor ExocoreBTCGateway to meet our needs:

- use `ClientChainID` enum to represent supported BTC like chains, and `Token` enum to represent tokens supported by `ExocoreBTCGateway`
- redesign and implement the way we deal with stake message
- redesign and implement the way we deal with peg out requests