### PR TITLE
update generate script for oracle state

### DIFF
--- a/script/bootstrap/generate.mjs
+++ b/script/bootstrap/generate.mjs
@@ -289,6 +289,9 @@ async function updateGenesisFile() {
         if (token.tokenAddress != VIRTUAL_STAKED_ETH_ADDR) {
           throw new Error('Oracle name refers to NST token but this is LST');
         }
+        if (TokenMappingChainIDsForOracle[tokenNamesForOracle[i]] == null) {
+          throw new Error(`Missing chain_id mapping for ${tokenNamesForOracle[i]}`);
+        }
         oracleToken = {
           name: tokenNamesForOracle[i],
           chain_id: TokenMappingChainIDsForOracle[tokenNamesForOracle[i]],
@@ -299,6 +302,9 @@ async function updateGenesisFile() {
         };
         oracleTokenFeeder.rule_id = "3";
       } else {
+        if (TokenMappingChainIDsForOracle[tokenNamesForOracle[i]] == null) {
+          throw new Error(`Missing chain_id mapping for ${tokenNamesForOracle[i]}`);
+       	}
         if (token.tokenAddress == VIRTUAL_STAKED_ETH_ADDR) {
           throw new Error('Oracle name refers to LST token but this is NST');
         }


### PR DESCRIPTION
## Changes
1. remove redundant code
2. correct tokenID of tokenFeeder with the index from token list
3. reset ruleID of tokenFeeder to 2 or 3 based on whether the token referred to is 'NST'

## TODO:
- [x] set exchange rate as price of roundID=0 for oracle state so that we can remove defaultPrice from oracle moudule
- [x] check? `params.Chains`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for additional oracle chains (including Ethereum) and per‑chain metadata.
  * Automatically initializes and populates chain and price data; generates per‑token price entries with 8‑decimal precision and price round tracking.
  * NST handling: auto‑adds missing base assets and feeders; supports multiple NSTs with validation.

* **Improvements**
  * More accurate chain mapping for tokens; NST precision updated to 9 decimals.
  * Staker state enriched with per‑validator structured info and NST version tracking.
  * Balance updates now accumulate correctly.

* **Bug Fixes**
  * Fixed price and NST resolution edge cases and ensured consistent initialization of oracle lists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->