### PR TITLE
feat(gateway): add oracleReceive to ImuachainGateway 

### DIFF
--- a/src/core/BaseRestakingController.sol
+++ b/src/core/BaseRestakingController.sol
@@ -29,6 +29,11 @@ abstract contract BaseRestakingController is
     IBaseRestakingController,
     ClientChainGatewayStorage
 {
+    /// @notice Emitted when a cross-chain payload is created for Imuachain.
+    /// @param nonce The LayerZero nonce for the request.
+    /// @param msgId The LayerZero guid for the request.
+    /// @param payload The raw payload sent to Imuachain.
+    event XChainMessage(uint64 nonce, bytes32 msgId, bytes payload);
 
     using OptionsBuilder for bytes;
 
@@ -129,6 +134,7 @@ abstract contract BaseRestakingController is
         MessagingReceipt memory receipt =
             _lzSend(IMUACHAIN_CHAIN_ID, payload, options, MessagingFee(fee.nativeFee, 0), msg.sender, false);
         emit MessageSent(action, receipt.guid, receipt.nonce, receipt.fee.nativeFee);
+        emit XChainMessage(receipt.nonce, receipt.guid, payload);
 
         return receipt.nonce;
     }

--- a/src/core/ImuachainGateway.sol
+++ b/src/core/ImuachainGateway.sol
@@ -346,6 +346,41 @@ contract ImuachainGateway is
         emit MessageExecuted(act, _origin.nonce);
     }
 
+    /// @inheritdoc IImuachainGateway
+    function oracleReceive(uint32 srcChainId, uint64 nonce, bytes calldata message)
+        external
+        whenNotPaused
+        nonReentrant
+    {
+        if (msg.sender != oracleCaller) {
+            revert Errors.ImuachainGatewayNotOracleCaller();
+        }
+        _validateMessageLength(message);
+
+        Action act = Action(uint8(message[0]));
+        bytes calldata payload = message[1:];
+        bytes4 selector_ = _whiteListFunctionSelectors[act];
+        if (selector_ == bytes4(0)) {
+            revert Errors.UnsupportedRequest(act);
+        }
+
+        (bool success, bytes memory responseOrReason) =
+            address(this).call(abi.encodePacked(selector_, abi.encode(srcChainId, nonce, act, payload)));
+        if (!success) {
+            revert Errors.RequestOrResponseExecuteFailed(act, nonce, responseOrReason);
+        }
+
+        emit OracleReceived(srcChainId, nonce, act);
+    }
+
+    /// @inheritdoc IImuachainGateway
+    function setOracleCaller(address oracleCaller_) external onlyOwner {
+        if (oracleCaller_ == address(0)) {
+            revert Errors.ZeroAddress();
+        }
+        oracleCaller = oracleCaller_;
+    }
+
     /// @notice Handles LST transfer from a client chain.
     /// @dev Can only be called from this contract via low-level call.
     /// @dev Returns empty bytes if the action is deposit, otherwise returns the lzNonce and success flag.

--- a/src/interfaces/IImuachainGateway.sol
+++ b/src/interfaces/IImuachainGateway.sol
@@ -77,4 +77,17 @@ interface IImuachainGateway is IOAppReceiver, IOAppCore {
     /// @param clientChainId The LayerZero chain id of the client chain.
     function markBootstrap(uint32 clientChainId) external payable;
 
+    /// @notice Receives a cross-chain message delivered by the oracle module instead of LayerZero.
+    /// @dev The message format is identical to what _lzReceive expects: [action_byte][payload].
+    ///      Only callable by the configured oracleCaller address. Unlike _lzReceive, this does
+    ///      not send LayerZero responses back to the source chain.
+    /// @param srcChainId The LayerZero endpoint ID of the source chain.
+    /// @param nonce The oracle-assigned nonce for this message.
+    /// @param message The raw message bytes (action + args), same format as LayerZero payload.
+    function oracleReceive(uint32 srcChainId, uint64 nonce, bytes calldata message) external;
+
+    /// @notice Sets the address authorized to call oracleReceive.
+    /// @param oracleCaller_ The oracle module's EVM address.
+    function setOracleCaller(address oracleCaller_) external;
+
 }

--- a/src/libraries/Errors.sol
+++ b/src/libraries/Errors.sol
@@ -224,6 +224,9 @@ library Errors {
     /// @dev ImuachainGateway: can only be called from this contract itself with a low-level call
     error ImuachainGatewayOnlyCalledFromThis();
 
+    /// @dev ImuachainGateway: caller is not the authorized oracle module address
+    error ImuachainGatewayNotOracleCaller();
+
     /// @dev ImuachainGateway: failed to get client chain ids
     error ImuachainGatewayFailedToGetClientChainIds();
 

--- a/src/storage/ImuachainGatewayStorage.sol
+++ b/src/storage/ImuachainGatewayStorage.sol
@@ -133,8 +133,17 @@ contract ImuachainGatewayStorage is GatewayStorage {
     /// @param clientChainId The LayerZero chain ID of chain to which it is destined.
     event BootstrapRequestSent(uint32 clientChainId);
 
+    /// @notice Emitted when a message is received and executed via the oracle bridge.
+    /// @param srcChainId The LayerZero endpoint ID of the source chain.
+    /// @param nonce The oracle-assigned nonce for this message.
+    /// @param act The action that was executed.
+    event OracleReceived(uint32 indexed srcChainId, uint64 nonce, Action act);
+
+    /// @notice The address authorized to call oracleReceive (oracle module EVM address).
+    address public oracleCaller;
+
     /// @dev Storage gap to allow for future upgrades.
-    uint256[40] private __gap;
+    uint256[39] private __gap;
 
     /**
      * @dev Validates the message length based on the action.

--- a/test/mocks/ImuachainGatewayMock.sol
+++ b/test/mocks/ImuachainGatewayMock.sol
@@ -360,6 +360,39 @@ contract ImuachainGatewayMock is
         emit MessageExecuted(act, _origin.nonce);
     }
 
+    function oracleReceive(uint32 srcChainId, uint64 nonce, bytes calldata message)
+        external
+        whenNotPaused
+        nonReentrant
+    {
+        if (msg.sender != oracleCaller) {
+            revert Errors.ImuachainGatewayNotOracleCaller();
+        }
+        _validateMessageLength(message);
+
+        Action act = Action(uint8(message[0]));
+        bytes calldata payload = message[1:];
+        bytes4 selector_ = _whiteListFunctionSelectors[act];
+        if (selector_ == bytes4(0)) {
+            revert Errors.UnsupportedRequest(act);
+        }
+
+        (bool success, bytes memory responseOrReason) =
+            address(this).call(abi.encodePacked(selector_, abi.encode(srcChainId, nonce, act, payload)));
+        if (!success) {
+            revert Errors.RequestOrResponseExecuteFailed(act, nonce, responseOrReason);
+        }
+
+        emit OracleReceived(srcChainId, nonce, act);
+    }
+
+    function setOracleCaller(address oracleCaller_) external onlyOwner {
+        if (oracleCaller_ == address(0)) {
+            revert Errors.ZeroAddress();
+        }
+        oracleCaller = oracleCaller_;
+    }
+
     /// @notice Handles LST transfer from a client chain.
     /// @dev Can only be called from this contract via low-level call.
     /// @dev Returns empty bytes if the action is deposit, otherwise returns the lzNonce and success flag.


### PR DESCRIPTION
The oracle module delivers cross-chain messages using the same payload format as LayerZero (action byte + args). Instead of a separate OracleGateway contract, reuse ImuachainGateway's existing dispatch table and handler functions via a new oracleReceive entry point that authenticates the oracle module address instead of the LZ endpoint.

Also emit XChainMessage on client-chain sends so the oracle feeder can pick up cross-chain payloads without depending on LayerZero.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added oracle-based cross-chain message receiving capability.
  * Added configuration interface for authorized oracle caller.
  * Added event tracking for cross-chain message transmission and receipt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->