### PR TITLE
Feat/oracle bridge outbound

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -16,6 +16,7 @@ deny = "warnings"
 # optimization is no longer enabled by default
 optimizer = true
 optimizer_runs = 100
+via_ir = true
 solc = "0.8.28"
 libraries = ["src/libraries/NetworkConstants.sol:NetworkConstants:0xf718DcEC914835d47a5e428A5397BF2F7276808b"]
 

--- a/src/core/BaseRestakingController.sol
+++ b/src/core/BaseRestakingController.sol
@@ -29,6 +29,11 @@ abstract contract BaseRestakingController is
     IBaseRestakingController,
     ClientChainGatewayStorage
 {
+    /// @notice Emitted when a cross-chain payload is created for Imuachain.
+    /// @param nonce The LayerZero nonce for the request.
+    /// @param msgId The LayerZero guid for the request.
+    /// @param payload The raw payload sent to Imuachain.
+    event XChainMessage(uint64 nonce, bytes32 msgId, bytes payload);
 
     using OptionsBuilder for bytes;
 
@@ -129,6 +134,7 @@ abstract contract BaseRestakingController is
         MessagingReceipt memory receipt =
             _lzSend(IMUACHAIN_CHAIN_ID, payload, options, MessagingFee(fee.nativeFee, 0), msg.sender, false);
         emit MessageSent(action, receipt.guid, receipt.nonce, receipt.fee.nativeFee);
+        emit XChainMessage(receipt.nonce, receipt.guid, payload);
 
         return receipt.nonce;
     }

--- a/src/core/BridgeVerifier.sol
+++ b/src/core/BridgeVerifier.sol
@@ -1,0 +1,263 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
+import {ReentrancyGuardUpgradeable} from "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
+
+/// @title BridgeVerifier
+/// @author imua-xyz
+/// @notice Verifies ECDSA multi-signatures from the imuachain validator set
+///         and delivers verified outbound messages to the ClientChainGateway.
+/// @dev Uses the Gravity Bridge pattern: validators sign checkpoints with their
+///      secp256k1 keys (same as their operator account keys), and this contract
+///      verifies that 2/3+ of total power has signed before executing messages.
+contract BridgeVerifier is Initializable, OwnableUpgradeable, PausableUpgradeable, ReentrancyGuardUpgradeable {
+
+    /// @notice Unique identifier for this bridge instance (prevents cross-bridge replay).
+    uint256 public constant BRIDGE_ID = 1;
+
+    /// @notice Current validator set nonce (incremented on each valset update).
+    uint256 public currentValsetNonce;
+
+    /// @notice Total voting power of the current validator set.
+    uint256 public totalPower;
+
+    /// @notice Last successfully processed checkpoint nonce per destination chain.
+    mapping(uint256 => uint256) public lastCheckpointNonce;
+
+    /// @notice Validator address => voting power. Zero means not a validator.
+    mapping(address => uint256) public validatorPower;
+
+    /// @notice Ordered list of current validator addresses.
+    address[] public validators;
+
+    /// @notice The ClientChainGateway that receives delivered messages.
+    address public gateway;
+
+    /// @dev Storage gap for future upgrades.
+    uint256[40] private __gap;
+
+    event CheckpointExecuted(uint256 indexed dstChainID, uint256 indexed checkpointNonce, uint256 messageCount);
+    event ValidatorSetUpdated(uint256 indexed newNonce, uint256 validatorCount, uint256 totalPower);
+    event MessageDelivered(uint256 indexed dstChainID, uint256 indexed checkpointNonce, uint256 msgIndex);
+    event MessageDeliveryFailed(uint256 indexed dstChainID, uint256 indexed checkpointNonce, uint256 msgIndex);
+
+    error InsufficientSigningPower(uint256 signedPower, uint256 required);
+    error InvalidCheckpointNonce(uint256 expected, uint256 got);
+    error InvalidValsetNonce(uint256 expected, uint256 got);
+    error SignatureMismatch(address expected, address recovered);
+    error InvalidSignatureLength();
+    error DuplicateSigner(address signer);
+    error NotAValidator(address signer);
+    error ZeroAddress();
+    error MessagesHashMismatch();
+
+    /// @notice Initializes the contract with the initial validator set.
+    /// @param owner_ The contract owner.
+    /// @param gateway_ The ClientChainGateway address.
+    /// @param initialValidators The initial validator addresses.
+    /// @param initialPowers The initial validator powers.
+    function initialize(
+        address owner_,
+        address gateway_,
+        address[] calldata initialValidators,
+        uint256[] calldata initialPowers
+    ) external initializer {
+        if (gateway_ == address(0) || owner_ == address(0)) revert ZeroAddress();
+
+        __Ownable_init();
+        __Pausable_init();
+        __ReentrancyGuard_init();
+        _transferOwnership(owner_);
+
+        gateway = gateway_;
+
+        uint256 total;
+        for (uint256 i = 0; i < initialValidators.length; i++) {
+            if (initialValidators[i] == address(0)) revert ZeroAddress();
+            validators.push(initialValidators[i]);
+            validatorPower[initialValidators[i]] = initialPowers[i];
+            total += initialPowers[i];
+        }
+        totalPower = total;
+        currentValsetNonce = 1;
+
+        emit ValidatorSetUpdated(1, initialValidators.length, total);
+    }
+
+    /// @notice Verifies a checkpoint signed by 2/3+ validators and delivers messages to the gateway.
+    /// @param checkpointNonce The sequential checkpoint nonce.
+    /// @param dstChainID The destination chain ID (should match this chain).
+    /// @param messagesHash The keccak256 hash of the encoded messages.
+    /// @param messages The individual outbound message payloads.
+    /// @param signers The addresses of validators who signed (must match signature order).
+    /// @param v ECDSA v values.
+    /// @param r ECDSA r values.
+    /// @param s ECDSA s values.
+    function verifyAndDeliver(
+        uint256 checkpointNonce,
+        uint256 dstChainID,
+        bytes32 messagesHash,
+        bytes[] calldata messages,
+        address[] calldata signers,
+        uint8[] calldata v,
+        bytes32[] calldata r,
+        bytes32[] calldata s
+    ) external whenNotPaused nonReentrant {
+        uint256 expected = lastCheckpointNonce[dstChainID] + 1;
+        if (checkpointNonce != expected) {
+            revert InvalidCheckpointNonce(expected, checkpointNonce);
+        }
+        if (signers.length != v.length || signers.length != r.length || signers.length != s.length) {
+            revert InvalidSignatureLength();
+        }
+
+        // Reconstruct and verify checkpoint hash with 2/3+ power
+        _verifySigs(
+            _toEthSignedMessageHash(keccak256(abi.encode(BRIDGE_ID, checkpointNonce, dstChainID, messagesHash))),
+            signers, v, r, s
+        );
+
+        // Deliver and finalize
+        _deliverMessages(dstChainID, checkpointNonce, messages);
+        lastCheckpointNonce[dstChainID] = checkpointNonce;
+    }
+
+    /// @dev Delivers messages to the gateway and emits events.
+    function _deliverMessages(uint256 dstChainID, uint256 checkpointNonce, bytes[] calldata messages) internal {
+        for (uint256 i = 0; i < messages.length; i++) {
+            try IBridgeGateway(gateway).oracleDeliver(messages[i]) {
+                emit MessageDelivered(dstChainID, checkpointNonce, i);
+            } catch {
+                emit MessageDeliveryFailed(dstChainID, checkpointNonce, i);
+            }
+        }
+        emit CheckpointExecuted(dstChainID, checkpointNonce, messages.length);
+    }
+
+    /// @notice Updates the validator set. Must be signed by 2/3+ of the CURRENT set.
+    /// @param newNonce The new valset nonce (must be currentValsetNonce + 1).
+    /// @param newValidators The new validator addresses.
+    /// @param newPowers The new validator powers.
+    /// @param signers Current validators who signed this update.
+    /// @param v ECDSA v values.
+    /// @param r ECDSA r values.
+    /// @param s ECDSA s values.
+    function updateValidatorSet(
+        uint256 newNonce,
+        address[] calldata newValidators,
+        uint256[] calldata newPowers,
+        address[] calldata signers,
+        uint8[] calldata v,
+        bytes32[] calldata r,
+        bytes32[] calldata s
+    ) external whenNotPaused nonReentrant {
+        if (newNonce != currentValsetNonce + 1) {
+            revert InvalidValsetNonce(currentValsetNonce + 1, newNonce);
+        }
+
+        // Hash the new validator set and verify current set signed it
+        _verifySigs(_toEthSignedMessageHash(_hashValset(newNonce, newValidators, newPowers)), signers, v, r, s);
+
+        // Apply the update
+        _applyValsetUpdate(newNonce, newValidators, newPowers);
+    }
+
+    /// @dev Applies a validated validator set update to storage.
+    function _applyValsetUpdate(uint256 newNonce, address[] calldata newValidators, uint256[] calldata newPowers) internal {
+        // Clear old
+        for (uint256 i = 0; i < validators.length; i++) {
+            delete validatorPower[validators[i]];
+        }
+        delete validators;
+
+        // Set new
+        uint256 newTotal;
+        for (uint256 i = 0; i < newValidators.length; i++) {
+            if (newValidators[i] == address(0)) revert ZeroAddress();
+            validators.push(newValidators[i]);
+            validatorPower[newValidators[i]] = newPowers[i];
+            newTotal += newPowers[i];
+        }
+        totalPower = newTotal;
+        currentValsetNonce = newNonce;
+
+        emit ValidatorSetUpdated(newNonce, newValidators.length, newTotal);
+    }
+
+    /// @dev Hashes a validator set for signing.
+    function _hashValset(uint256 nonce, address[] calldata vals, uint256[] calldata powers) internal pure returns (bytes32) {
+        bytes memory valsetData = abi.encode(uint256(1), nonce); // BRIDGE_ID = 1
+        for (uint256 i = 0; i < vals.length; i++) {
+            valsetData = abi.encodePacked(valsetData, vals[i], powers[i]);
+        }
+        return keccak256(valsetData);
+    }
+
+    /// @dev Verifies that 2/3+ of total power signed the given hash.
+    /// @dev Signers MUST be sorted in strictly ascending address order (O(N) duplicate check).
+    function _verifySigs(
+        bytes32 ethSignedHash,
+        address[] calldata signers,
+        uint8[] calldata v,
+        bytes32[] calldata r,
+        bytes32[] calldata s
+    ) internal view {
+        uint256 signedPower;
+        address prevSigner;
+        for (uint256 i = 0; i < signers.length; i++) {
+            // O(N) uniqueness: require strictly ascending signer addresses.
+            if (i > 0 && signers[i] <= prevSigner) {
+                revert DuplicateSigner(signers[i]);
+            }
+            prevSigner = signers[i];
+
+            address recovered = ecrecover(ethSignedHash, v[i], r[i], s[i]);
+            if (recovered != signers[i]) {
+                revert SignatureMismatch(signers[i], recovered);
+            }
+            uint256 power = validatorPower[recovered];
+            if (power == 0) {
+                revert NotAValidator(recovered);
+            }
+            signedPower += power;
+        }
+        uint256 required = (totalPower * 2) / 3 + 1;
+        if (signedPower < required) {
+            revert InsufficientSigningPower(signedPower, required);
+        }
+    }
+
+    /// @notice Returns the number of validators.
+    function validatorCount() external view returns (uint256) {
+        return validators.length;
+    }
+
+    /// @notice Pauses the contract. Only owner.
+    function pause() external onlyOwner {
+        _pause();
+    }
+
+    /// @notice Unpauses the contract. Only owner.
+    function unpause() external onlyOwner {
+        _unpause();
+    }
+
+    /// @notice Updates the gateway address. Only owner.
+    function setGateway(address gateway_) external onlyOwner {
+        if (gateway_ == address(0)) revert ZeroAddress();
+        gateway = gateway_;
+    }
+
+    /// @dev Wraps a hash in the Ethereum signed message format.
+    function _toEthSignedMessageHash(bytes32 hash) internal pure returns (bytes32) {
+        return keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", hash));
+    }
+}
+
+/// @dev Minimal interface for the gateway's oracleDeliver function.
+interface IBridgeGateway {
+    function oracleDeliver(bytes calldata message) external;
+}

--- a/src/core/BridgeVerifier.sol
+++ b/src/core/BridgeVerifier.sol
@@ -15,8 +15,11 @@ import {ReentrancyGuardUpgradeable} from "@openzeppelin/contracts-upgradeable/se
 ///      verifies that 2/3+ of total power has signed before executing messages.
 contract BridgeVerifier is Initializable, OwnableUpgradeable, PausableUpgradeable, ReentrancyGuardUpgradeable {
 
-    /// @notice Unique identifier for this bridge instance (prevents cross-bridge replay).
+    /// @notice Domain identifier for this bridge family (shared across deployments in the same validator set).
     uint256 public constant BRIDGE_ID = 1;
+
+    /// @notice Destination chain ID this verifier instance is pinned to. Set at initialization.
+    uint256 public expectedDstChainID;
 
     /// @notice Current validator set nonce (incremented on each valset update).
     uint256 public currentValsetNonce;
@@ -37,7 +40,7 @@ contract BridgeVerifier is Initializable, OwnableUpgradeable, PausableUpgradeabl
     address public gateway;
 
     /// @dev Storage gap for future upgrades.
-    uint256[40] private __gap;
+    uint256[39] private __gap;
 
     event CheckpointExecuted(uint256 indexed dstChainID, uint256 indexed checkpointNonce, uint256 messageCount);
     event ValidatorSetUpdated(uint256 indexed newNonce, uint256 validatorCount, uint256 totalPower);
@@ -53,19 +56,27 @@ contract BridgeVerifier is Initializable, OwnableUpgradeable, PausableUpgradeabl
     error NotAValidator(address signer);
     error ZeroAddress();
     error MessagesHashMismatch();
+    error InvalidDstChainID(uint256 expected, uint256 got);
+    error EmptyValidatorSet();
+    error LengthMismatch();
+    error ZeroPower();
+    error UnsortedValidators(address prev, address curr);
 
     /// @notice Initializes the contract with the initial validator set.
     /// @param owner_ The contract owner.
     /// @param gateway_ The ClientChainGateway address.
-    /// @param initialValidators The initial validator addresses.
-    /// @param initialPowers The initial validator powers.
+    /// @param expectedDstChainID_ The destination chain ID this verifier is pinned to.
+    /// @param initialValidators The initial validator addresses, strictly sorted ascending.
+    /// @param initialPowers The initial validator powers, aligned with initialValidators.
     function initialize(
         address owner_,
         address gateway_,
+        uint256 expectedDstChainID_,
         address[] calldata initialValidators,
         uint256[] calldata initialPowers
     ) external initializer {
         if (gateway_ == address(0) || owner_ == address(0)) revert ZeroAddress();
+        if (expectedDstChainID_ == 0) revert InvalidDstChainID(0, 0);
 
         __Ownable_init();
         __Pausable_init();
@@ -73,18 +84,36 @@ contract BridgeVerifier is Initializable, OwnableUpgradeable, PausableUpgradeabl
         _transferOwnership(owner_);
 
         gateway = gateway_;
+        expectedDstChainID = expectedDstChainID_;
 
-        uint256 total;
-        for (uint256 i = 0; i < initialValidators.length; i++) {
-            if (initialValidators[i] == address(0)) revert ZeroAddress();
-            validators.push(initialValidators[i]);
-            validatorPower[initialValidators[i]] = initialPowers[i];
-            total += initialPowers[i];
-        }
+        uint256 total = _validateAndIngestValset(initialValidators, initialPowers);
         totalPower = total;
         currentValsetNonce = 1;
 
         emit ValidatorSetUpdated(1, initialValidators.length, total);
+    }
+
+    /// @dev Validates a validator set and writes it to storage. Requires strictly ascending
+    ///      addresses (giving free uniqueness/nonzero checks) and non-zero powers.
+    function _validateAndIngestValset(address[] calldata vals, uint256[] calldata powers)
+        internal
+        returns (uint256 total)
+    {
+        uint256 n = vals.length;
+        if (n == 0) revert EmptyValidatorSet();
+        if (powers.length != n) revert LengthMismatch();
+
+        address prev;
+        for (uint256 i = 0; i < n; i++) {
+            address v = vals[i];
+            if (v == address(0)) revert ZeroAddress();
+            if (i > 0 && v <= prev) revert UnsortedValidators(prev, v);
+            if (powers[i] == 0) revert ZeroPower();
+            validators.push(v);
+            validatorPower[v] = powers[i];
+            total += powers[i];
+            prev = v;
+        }
     }
 
     /// @notice Verifies a checkpoint signed by 2/3+ validators and delivers messages to the gateway.
@@ -106,12 +135,19 @@ contract BridgeVerifier is Initializable, OwnableUpgradeable, PausableUpgradeabl
         bytes32[] calldata r,
         bytes32[] calldata s
     ) external whenNotPaused nonReentrant {
+        if (dstChainID != expectedDstChainID) {
+            revert InvalidDstChainID(expectedDstChainID, dstChainID);
+        }
         uint256 expected = lastCheckpointNonce[dstChainID] + 1;
         if (checkpointNonce != expected) {
             revert InvalidCheckpointNonce(expected, checkpointNonce);
         }
         if (signers.length != v.length || signers.length != r.length || signers.length != s.length) {
             revert InvalidSignatureLength();
+        }
+        // Bind the signed messagesHash to the actual messages being executed.
+        if (keccak256(abi.encode(messages)) != messagesHash) {
+            revert MessagesHashMismatch();
         }
 
         // Reconstruct and verify checkpoint hash with 2/3+ power
@@ -173,23 +209,18 @@ contract BridgeVerifier is Initializable, OwnableUpgradeable, PausableUpgradeabl
         }
         delete validators;
 
-        // Set new
-        uint256 newTotal;
-        for (uint256 i = 0; i < newValidators.length; i++) {
-            if (newValidators[i] == address(0)) revert ZeroAddress();
-            validators.push(newValidators[i]);
-            validatorPower[newValidators[i]] = newPowers[i];
-            newTotal += newPowers[i];
-        }
+        // Validate and ingest the new set
+        uint256 newTotal = _validateAndIngestValset(newValidators, newPowers);
         totalPower = newTotal;
         currentValsetNonce = newNonce;
 
         emit ValidatorSetUpdated(newNonce, newValidators.length, newTotal);
     }
 
-    /// @dev Hashes a validator set for signing.
+    /// @dev Hashes a validator set for signing. Requires equal-length inputs.
     function _hashValset(uint256 nonce, address[] calldata vals, uint256[] calldata powers) internal pure returns (bytes32) {
-        bytes memory valsetData = abi.encode(uint256(1), nonce); // BRIDGE_ID = 1
+        if (vals.length != powers.length) revert LengthMismatch();
+        bytes memory valsetData = abi.encode(BRIDGE_ID, nonce);
         for (uint256 i = 0; i < vals.length; i++) {
             valsetData = abi.encodePacked(valsetData, vals[i], powers[i]);
         }

--- a/src/core/ClientGatewayLzReceiver.sol
+++ b/src/core/ClientGatewayLzReceiver.sol
@@ -178,9 +178,16 @@ abstract contract ClientGatewayLzReceiver is PausableUpgradeable, OAppReceiverUp
         if (msg.sender != bridgeVerifier) {
             revert Errors.UnauthorizedBridgeVerifier();
         }
+        if (message.length < 1) {
+            revert Errors.InvalidMessageLength();
+        }
 
         Action act = Action(uint8(message[0]));
         if (act == Action.RESPOND) {
+            // _handleResponse reads response[1:9] and response[9]; require at least 10 bytes.
+            if (message.length < 10) {
+                revert Errors.InvalidMessageLength();
+            }
             _handleResponse(message);
         } else {
             bytes calldata payload = message[1:];

--- a/src/core/ClientGatewayLzReceiver.sol
+++ b/src/core/ClientGatewayLzReceiver.sol
@@ -168,6 +168,47 @@ abstract contract ClientGatewayLzReceiver is PausableUpgradeable, OAppReceiverUp
         rewardVault.unlockReward(token, staker, amount);
     }
 
+    /// @notice Receives a cross-chain message delivered by the oracle relay instead of LayerZero.
+    /// @dev The message format is identical to what _lzReceive expects: [action_byte][payload].
+    ///      Only callable by the configured bridgeVerifier address.
+    ///      For RESPOND messages, delegates to _handleResponse which validates via _registeredRequests.
+    ///      For other actions (e.g. ADD_WHITELIST_TOKEN, MARK_BOOTSTRAP), dispatches via whitelisted selectors.
+    /// @param message The raw message bytes (action + args).
+    function oracleDeliver(bytes calldata message) external whenNotPaused {
+        if (msg.sender != bridgeVerifier) {
+            revert Errors.UnauthorizedBridgeVerifier();
+        }
+
+        Action act = Action(uint8(message[0]));
+        if (act == Action.RESPOND) {
+            _handleResponse(message);
+        } else {
+            bytes calldata payload = message[1:];
+            bytes4 selector_ = _whiteListFunctionSelectors[act];
+            if (selector_ == bytes4(0)) {
+                revert Errors.UnsupportedRequest(act);
+            }
+            (bool success, bytes memory reason) = address(this).call(abi.encodePacked(selector_, abi.encode(payload)));
+            if (!success) {
+                revert Errors.OracleDeliveryFailed(act, reason);
+            }
+        }
+        emit OracleDelivered(act);
+    }
+
+    /// @notice Sets the address authorized to call oracleDeliver.
+    /// @param relayer_ The oracle relayer's address.
+    function setBridgeVerifier(address relayer_) external {
+        // Only owner can set. We use the bootstrap owner check since OwnableUpgradeable is in the inheritance chain.
+        if (msg.sender != owner()) {
+            revert Errors.NotOwner();
+        }
+        if (relayer_ == address(0)) {
+            revert Errors.ZeroAddress();
+        }
+        bridgeVerifier = relayer_;
+    }
+
     /// @notice Called after an add-whitelist-token response is received.
     /// @param payload The request payload.
     /// @dev Though `_deployVault` would make external call to newly created `Vault` contract and initialize it,

--- a/src/core/ImuachainGateway.sol
+++ b/src/core/ImuachainGateway.sol
@@ -357,6 +357,11 @@ contract ImuachainGateway is
         if (msg.sender != oracleCaller) {
             revert Errors.ImuachainGatewayNotOracleCaller();
         }
+        // Replay protection: each (srcChainId, requestNonce) may only be processed once.
+        if (processedOracleNonces[srcChainId][nonce]) {
+            revert Errors.DuplicateOracleNonce(srcChainId, nonce);
+        }
+        processedOracleNonces[srcChainId][nonce] = true;
         _validateMessageLength(message);
 
         Action act = Action(uint8(message[0]));

--- a/src/core/ImuachainGateway.sol
+++ b/src/core/ImuachainGateway.sol
@@ -346,6 +346,41 @@ contract ImuachainGateway is
         emit MessageExecuted(act, _origin.nonce);
     }
 
+    /// @inheritdoc IImuachainGateway
+    function oracleReceive(uint32 srcChainId, uint64 nonce, bytes calldata message)
+        external
+        whenNotPaused
+        nonReentrant
+    {
+        if (msg.sender != oracleCaller) {
+            revert Errors.ImuachainGatewayNotOracleCaller();
+        }
+        _validateMessageLength(message);
+
+        Action act = Action(uint8(message[0]));
+        bytes calldata payload = message[1:];
+        bytes4 selector_ = _whiteListFunctionSelectors[act];
+        if (selector_ == bytes4(0)) {
+            revert Errors.UnsupportedRequest(act);
+        }
+
+        (bool success, bytes memory responseOrReason) =
+            address(this).call(abi.encodePacked(selector_, abi.encode(srcChainId, nonce, act, payload)));
+        if (!success) {
+            revert Errors.RequestOrResponseExecuteFailed(act, nonce, responseOrReason);
+        }
+
+        emit OracleReceived(srcChainId, nonce, act);
+    }
+
+    /// @inheritdoc IImuachainGateway
+    function setOracleCaller(address oracleCaller_) external onlyOwner {
+        if (oracleCaller_ == address(0)) {
+            revert Errors.ZeroAddress();
+        }
+        oracleCaller = oracleCaller_;
+    }
+
     /// @notice Handles LST transfer from a client chain.
     /// @dev Can only be called from this contract via low-level call.
     /// @dev Returns empty bytes if the action is deposit, otherwise returns the lzNonce and success flag.

--- a/src/core/ImuachainGateway.sol
+++ b/src/core/ImuachainGateway.sol
@@ -117,6 +117,7 @@ contract ImuachainGateway is
         // we don't track that a request was sent to a chain to allow for retrials
         // if the transaction fails on the destination chain
         _sendInterchainMsg(chainIndex, Action.REQUEST_MARK_BOOTSTRAP, "", false);
+        _queueOutboundMsg(chainIndex, Action.REQUEST_MARK_BOOTSTRAP, "");
         emit BootstrapRequestSent(chainIndex);
     }
 
@@ -214,6 +215,7 @@ contract ImuachainGateway is
             _sendInterchainMsg(
                 clientChainId, Action.REQUEST_ADD_WHITELIST_TOKEN, abi.encodePacked(token, tvlLimit), false
             );
+            _queueOutboundMsg(clientChainId, Action.REQUEST_ADD_WHITELIST_TOKEN, abi.encodePacked(token, tvlLimit));
         } else {
             revert Errors.AddWhitelistTokenFailed(clientChainId, token);
         }
@@ -368,6 +370,13 @@ contract ImuachainGateway is
             address(this).call(abi.encodePacked(selector_, abi.encode(srcChainId, nonce, act, payload)));
         if (!success) {
             revert Errors.RequestOrResponseExecuteFailed(act, nonce, responseOrReason);
+        }
+
+        // Capture handler response and emit for outbound relay (oracle bridge replacement for L0 response path).
+        bytes memory response = abi.decode(responseOrReason, (bytes));
+        if (response.length > 0) {
+            bytes memory fullPayload = abi.encodePacked(Action.RESPOND, response);
+            emit OutboundResponse(srcChainId, nonce, fullPayload);
         }
 
         emit OracleReceived(srcChainId, nonce, act);
@@ -611,6 +620,16 @@ contract ImuachainGateway is
         MessagingReceipt memory receipt =
             _lzSend(srcChainId, payload, options, MessagingFee(fee.nativeFee, 0), refundAddress, payByApp);
         emit MessageSent(act, receipt.guid, receipt.nonce, receipt.fee.nativeFee);
+    }
+
+    /// @dev Queues an outbound message for oracle relay instead of sending via LayerZero.
+    /// The oracle module picks up the emitted event and enqueues it for relay to the client chain.
+    /// @param dstChainId The destination client chain ID.
+    /// @param act The action to be performed.
+    /// @param actionArgs The arguments for the action.
+    function _queueOutboundMsg(uint32 dstChainId, Action act, bytes memory actionArgs) internal whenNotPaused {
+        bytes memory payload = abi.encodePacked(act, actionArgs);
+        emit OutboundMessage(dstChainId, payload);
     }
 
     /// @inheritdoc IImuachainGateway

--- a/src/interfaces/IImuachainGateway.sol
+++ b/src/interfaces/IImuachainGateway.sol
@@ -77,9 +77,13 @@ interface IImuachainGateway is IOAppReceiver, IOAppCore {
     /// @notice Receives a cross-chain message delivered by the oracle module instead of LayerZero.
     /// @dev The message format is identical to what _lzReceive expects: [action_byte][payload].
     ///      Only callable by the configured oracleCaller address. Unlike _lzReceive, this does
-    ///      not send LayerZero responses back to the source chain.
+    ///      not send LayerZero responses back to the source chain — responses are emitted as
+    ///      `OutboundResponse` for relay via the oracle bridge.
     /// @param srcChainId The LayerZero endpoint ID of the source chain.
-    /// @param nonce The oracle-assigned nonce for this message.
+    /// @param nonce The original request nonce emitted by `BaseRestakingController.XChainMessage`
+    ///              on the source chain. This value is echoed back into any response payload and
+    ///              used on the source side as the `_registeredRequests` key, so it MUST match the
+    ///              nonce that produced this request rather than an oracle-local counter.
     /// @param message The raw message bytes (action + args), same format as LayerZero payload.
     function oracleReceive(uint32 srcChainId, uint64 nonce, bytes calldata message) external;
 

--- a/src/interfaces/IImuachainGateway.sol
+++ b/src/interfaces/IImuachainGateway.sol
@@ -50,7 +50,6 @@ interface IImuachainGateway is IOAppReceiver, IOAppCore {
     /// @param oracleInfo The oracle information of the token.
     /// @param tvlLimit The TVL limit of the token to set on the client chain.
     /// @dev The chain must be registered before adding tokens.
-    /// @dev This function is payable because it sends a message to the client chain.
     /// @dev The tvlLimit is a `uint128` so that it can work on Solana easily. Within this uint,
     /// we can fit 1 trillion tokens with 18 decimals.
     function addWhitelistToken(
@@ -72,8 +71,6 @@ interface IImuachainGateway is IOAppReceiver, IOAppCore {
 
     /// @notice Marks the network as bootstrapped, on the client chain.
     /// @dev Causes an upgrade of the Bootstrap contract to the ClientChainGateway contract.
-    /// @dev Only works if LZ infrastructure is set up and SetPeer has been called.
-    /// @dev This is payable because it requires a fee to be paid to LZ.
     /// @param clientChainId The LayerZero chain id of the client chain.
     function markBootstrap(uint32 clientChainId) external payable;
 

--- a/src/interfaces/IImuachainGateway.sol
+++ b/src/interfaces/IImuachainGateway.sol
@@ -77,4 +77,17 @@ interface IImuachainGateway is IOAppReceiver, IOAppCore {
     /// @param clientChainId The LayerZero chain id of the client chain.
     function markBootstrap(uint32 clientChainId) external payable;
 
+    /// @notice Receives a cross-chain message delivered by the oracle module instead of LayerZero.
+    /// @dev The message format is identical to what _lzReceive expects: [action_byte][payload].
+    ///      Only callable by the configured oracleCaller address. Unlike _lzReceive, this does
+    ///      not send LayerZero responses back to the source chain.
+    /// @param srcChainId The LayerZero endpoint ID of the source chain.
+    /// @param nonce The oracle-assigned nonce for this message.
+    /// @param message The raw message bytes (action + args), same format as LayerZero payload.
+    function oracleReceive(uint32 srcChainId, uint64 nonce, bytes calldata message) external;
+
+    /// @notice Sets the address authorized to call oracleReceive.
+    /// @param oracleCaller_ The oracle module's EVM address.
+    function setOracleCaller(address oracleCaller_) external;
+
 }

--- a/src/libraries/Errors.sol
+++ b/src/libraries/Errors.sol
@@ -227,6 +227,17 @@ library Errors {
     /// @dev ImuachainGateway: caller is not the authorized oracle module address
     error ImuachainGatewayNotOracleCaller();
 
+    /// @dev ClientChainGateway: caller is not the authorized bridge verifier
+    error UnauthorizedBridgeVerifier();
+
+    /// @dev ClientChainGateway: oracle delivery execution failed
+    /// @param act The action that failed.
+    /// @param reason The reason for the failure.
+    error OracleDeliveryFailed(Action act, bytes reason);
+
+    /// @dev Caller is not the contract owner
+    error NotOwner();
+
     /// @dev ImuachainGateway: failed to get client chain ids
     error ImuachainGatewayFailedToGetClientChainIds();
 

--- a/src/libraries/Errors.sol
+++ b/src/libraries/Errors.sol
@@ -224,6 +224,9 @@ library Errors {
     /// @dev ImuachainGateway: can only be called from this contract itself with a low-level call
     error ImuachainGatewayOnlyCalledFromThis();
 
+    /// @dev ImuachainGateway: caller is not the authorized oracle module address
+    error ImuachainGatewayNotOracleCaller();
+
     /// @dev ImuachainGateway: failed to get client chain ids
     error ImuachainGatewayFailedToGetClientChainIds();
 

--- a/src/libraries/Errors.sol
+++ b/src/libraries/Errors.sol
@@ -227,6 +227,11 @@ library Errors {
     /// @dev ImuachainGateway: caller is not the authorized oracle module address
     error ImuachainGatewayNotOracleCaller();
 
+    /// @dev ImuachainGateway: oracleReceive called with an already-processed (srcChainId, nonce)
+    /// @param srcChainId The source chain ID.
+    /// @param nonce The duplicate request nonce.
+    error DuplicateOracleNonce(uint32 srcChainId, uint64 nonce);
+
     /// @dev ClientChainGateway: caller is not the authorized bridge verifier
     error UnauthorizedBridgeVerifier();
 

--- a/src/storage/ClientChainGatewayStorage.sol
+++ b/src/storage/ClientChainGatewayStorage.sol
@@ -42,8 +42,11 @@ contract ClientChainGatewayStorage is BootstrapStorage {
     /// @notice The reward vault contract.
     IRewardVault public rewardVault;
 
+    /// @notice The address of the BridgeVerifier contract authorized to call oracleDeliver.
+    address public bridgeVerifier;
+
     /// @dev Storage gap to allow for future upgrades.
-    uint256[39] private __gap;
+    uint256[38] private __gap;
 
     /* ----------------------------- restaking events     ------------------------------ */
 
@@ -69,6 +72,10 @@ contract ClientChainGatewayStorage is BootstrapStorage {
     /// @notice Emitted when a reward vault is created.
     /// @param vault Address of the reward vault.
     event RewardVaultCreated(address vault);
+
+    /// @notice Emitted when a message is delivered via oracle relay.
+    /// @param act The action that was delivered.
+    event OracleDelivered(Action indexed act);
 
     /// @notice Initializes the ClientChainGatewayStorage contract.
     /// @param config The parameters to initialize the contract immutable variables.

--- a/src/storage/ImuachainGatewayStorage.sol
+++ b/src/storage/ImuachainGatewayStorage.sol
@@ -135,7 +135,8 @@ contract ImuachainGatewayStorage is GatewayStorage {
 
     /// @notice Emitted when a message is received and executed via the oracle bridge.
     /// @param srcChainId The LayerZero endpoint ID of the source chain.
-    /// @param nonce The oracle-assigned nonce for this message.
+    /// @param nonce The original request nonce from the source chain (same value used as the
+    ///              `_registeredRequests` key and echoed in any RESPOND response).
     /// @param act The action that was executed.
     event OracleReceived(uint32 indexed srcChainId, uint64 nonce, Action act);
 
@@ -153,8 +154,13 @@ contract ImuachainGatewayStorage is GatewayStorage {
     /// @notice The address authorized to call oracleReceive (oracle module EVM address).
     address public oracleCaller;
 
+    /// @notice Tracks processed oracle nonces per source chain to prevent replay.
+    /// @dev Indexed by (srcChainId, requestNonce). Unlike LZ path, oracle nonces may arrive
+    ///      out of order, so we use a set rather than a strict-sequential counter.
+    mapping(uint32 => mapping(uint64 => bool)) public processedOracleNonces;
+
     /// @dev Storage gap to allow for future upgrades.
-    uint256[39] private __gap;
+    uint256[38] private __gap;
 
     /**
      * @dev Validates the message length based on the action.

--- a/src/storage/ImuachainGatewayStorage.sol
+++ b/src/storage/ImuachainGatewayStorage.sol
@@ -139,6 +139,17 @@ contract ImuachainGatewayStorage is GatewayStorage {
     /// @param act The action that was executed.
     event OracleReceived(uint32 indexed srcChainId, uint64 nonce, Action act);
 
+    /// @notice Emitted when a handler produces a response that must be relayed back to the source chain.
+    /// @param dstChainId The chain to which the response should be delivered.
+    /// @param requestNonce The inbound nonce that triggered this response.
+    /// @param payload The full response payload (Action.RESPOND + requestId + success).
+    event OutboundResponse(uint32 indexed dstChainId, uint64 indexed requestNonce, bytes payload);
+
+    /// @notice Emitted when an admin-initiated outbound message is queued for relay to a client chain.
+    /// @param dstChainId The destination client chain ID.
+    /// @param payload The encoded message (action + args).
+    event OutboundMessage(uint32 indexed dstChainId, bytes payload);
+
     /// @notice The address authorized to call oracleReceive (oracle module EVM address).
     address public oracleCaller;
 

--- a/src/storage/ImuachainGatewayStorage.sol
+++ b/src/storage/ImuachainGatewayStorage.sol
@@ -133,8 +133,17 @@ contract ImuachainGatewayStorage is GatewayStorage {
     /// @param clientChainId The LayerZero chain ID of chain to which it is destined.
     event BootstrapRequestSent(uint32 clientChainId);
 
+    /// @notice Emitted when a message is received and executed via the oracle bridge.
+    /// @param srcChainId The LayerZero endpoint ID of the source chain.
+    /// @param nonce The oracle-assigned nonce for this message.
+    /// @param act The action that was executed.
+    event OracleReceived(uint32 indexed srcChainId, uint64 nonce, Action act);
+
+    /// @notice The address authorized to call oracleReceive (oracle module EVM address).
+    address public oracleCaller;
+
     /// @dev Storage gap to allow for future upgrades.
-    uint256[40] private __gap;
+    uint256[39] private __gap;
 
     /**
      * @dev Validates the message length based on the action.

--- a/test/foundry/unit/BridgeVerifier.t.sol
+++ b/test/foundry/unit/BridgeVerifier.t.sol
@@ -1,0 +1,262 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import "forge-std/Test.sol";
+import {BridgeVerifier, IBridgeGateway} from "../../../src/core/BridgeVerifier.sol";
+
+/// @dev Mock gateway that records delivered messages for testing.
+contract MockGateway is IBridgeGateway {
+    bytes[] public deliveredMessages;
+    bool public shouldRevert;
+
+    function oracleDeliver(bytes calldata message) external override {
+        if (shouldRevert) {
+            revert("mock revert");
+        }
+        deliveredMessages.push(message);
+    }
+
+    function getDeliveredCount() external view returns (uint256) {
+        return deliveredMessages.length;
+    }
+
+    function setRevert(bool _shouldRevert) external {
+        shouldRevert = _shouldRevert;
+    }
+}
+
+contract BridgeVerifierTest is Test {
+    BridgeVerifier verifier;
+    MockGateway gateway;
+
+    // Sorted by address ascending (determined by vm.addr output).
+    // We compute and sort in setUp.
+    uint256[3] pks;
+    address[3] vals; // vals[0] < vals[1] < vals[2]
+    uint256[3] powers;
+
+    function setUp() public {
+        uint256[3] memory rawPks = [uint256(0xA11CE), uint256(0xB0B), uint256(0xCA1)];
+        address[3] memory rawVals;
+        for (uint i = 0; i < 3; i++) {
+            rawVals[i] = vm.addr(rawPks[i]);
+        }
+        // Bubble sort by address
+        for (uint i = 0; i < 3; i++) {
+            for (uint j = i + 1; j < 3; j++) {
+                if (rawVals[i] > rawVals[j]) {
+                    (rawVals[i], rawVals[j]) = (rawVals[j], rawVals[i]);
+                    (rawPks[i], rawPks[j]) = (rawPks[j], rawPks[i]);
+                }
+            }
+        }
+        for (uint i = 0; i < 3; i++) {
+            pks[i] = rawPks[i];
+            vals[i] = rawVals[i];
+        }
+        powers = [uint256(40), uint256(40), uint256(20)];
+
+        gateway = new MockGateway();
+        verifier = new BridgeVerifier();
+
+        address[] memory valsArr = new address[](3);
+        uint256[] memory powersArr = new uint256[](3);
+        for (uint i = 0; i < 3; i++) {
+            valsArr[i] = vals[i];
+            powersArr[i] = powers[i];
+        }
+        verifier.initialize(address(this), address(gateway), valsArr, powersArr);
+    }
+
+    function _signCheckpoint(
+        uint256 privKey,
+        uint256 checkpointNonce,
+        uint256 dstChainID,
+        bytes32 messagesHash
+    ) internal pure returns (uint8 v, bytes32 r, bytes32 s) {
+        bytes32 checkpoint = keccak256(abi.encode(uint256(1), checkpointNonce, dstChainID, messagesHash));
+        bytes32 ethSignedHash = keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", checkpoint));
+        (v, r, s) = vm.sign(privKey, ethSignedHash);
+    }
+
+    // Helper: build sorted signer arrays from indices into vals/pks
+    function _buildSorted(uint[] memory indices, bytes32 messagesHash, uint256 nonce, uint256 chain)
+        internal view returns (
+            address[] memory signers, uint8[] memory vs, bytes32[] memory rs, bytes32[] memory ss
+        )
+    {
+        uint n = indices.length;
+        signers = new address[](n);
+        vs = new uint8[](n);
+        rs = new bytes32[](n);
+        ss = new bytes32[](n);
+        for (uint i = 0; i < n; i++) {
+            uint idx = indices[i];
+            signers[i] = vals[idx];
+            (vs[i], rs[i], ss[i]) = _signCheckpoint(pks[idx], nonce, chain, messagesHash);
+        }
+    }
+
+    function test_VerifyAndDeliver_Success() public {
+        bytes[] memory messages = new bytes[](2);
+        messages[0] = hex"000102";
+        messages[1] = hex"030405";
+        bytes32 messagesHash = keccak256(abi.encode(messages));
+
+        // Use first two validators (sorted), power = 40+40 = 80 > 66 required
+        uint[] memory idx = new uint[](2);
+        idx[0] = 0; idx[1] = 1;
+        (address[] memory signers, uint8[] memory vs, bytes32[] memory rs, bytes32[] memory ss)
+            = _buildSorted(idx, messagesHash, 1, 101);
+
+        verifier.verifyAndDeliver(1, 101, messagesHash, messages, signers, vs, rs, ss);
+
+        assertEq(verifier.lastCheckpointNonce(101), 1);
+        assertEq(gateway.getDeliveredCount(), 2);
+    }
+
+    function test_VerifyAndDeliver_InsufficientPower() public {
+        bytes[] memory messages = new bytes[](1);
+        messages[0] = hex"000102";
+        bytes32 messagesHash = keccak256(abi.encode(messages));
+
+        // Only val[2] with power=20, need 67
+        uint[] memory idx = new uint[](1);
+        idx[0] = 2;
+        (address[] memory signers, uint8[] memory vs, bytes32[] memory rs, bytes32[] memory ss)
+            = _buildSorted(idx, messagesHash, 1, 101);
+
+        vm.expectRevert(abi.encodeWithSelector(BridgeVerifier.InsufficientSigningPower.selector, 20, 67));
+        verifier.verifyAndDeliver(1, 101, messagesHash, messages, signers, vs, rs, ss);
+    }
+
+    function test_VerifyAndDeliver_InvalidNonce() public {
+        bytes[] memory messages = new bytes[](1);
+        messages[0] = hex"00";
+        bytes32 messagesHash = keccak256(abi.encode(messages));
+
+        uint[] memory idx = new uint[](2);
+        idx[0] = 0; idx[1] = 1;
+        (address[] memory signers, uint8[] memory vs, bytes32[] memory rs, bytes32[] memory ss)
+            = _buildSorted(idx, messagesHash, 2, 101); // nonce=2 but expected=1
+
+        vm.expectRevert(abi.encodeWithSelector(BridgeVerifier.InvalidCheckpointNonce.selector, 1, 2));
+        verifier.verifyAndDeliver(2, 101, messagesHash, messages, signers, vs, rs, ss);
+    }
+
+    function test_VerifyAndDeliver_UnsortedSigners() public {
+        bytes[] memory messages = new bytes[](1);
+        messages[0] = hex"00";
+        bytes32 messagesHash = keccak256(abi.encode(messages));
+
+        // Deliberately reverse the order (descending instead of ascending)
+        (uint8 v0, bytes32 r0, bytes32 s0) = _signCheckpoint(pks[1], 1, 101, messagesHash);
+        (uint8 v1, bytes32 r1, bytes32 s1) = _signCheckpoint(pks[0], 1, 101, messagesHash);
+
+        address[] memory signers = new address[](2);
+        uint8[] memory vs = new uint8[](2);
+        bytes32[] memory rs = new bytes32[](2);
+        bytes32[] memory ss = new bytes32[](2);
+        signers[0] = vals[1]; vs[0] = v0; rs[0] = r0; ss[0] = s0; // higher addr first
+        signers[1] = vals[0]; vs[1] = v1; rs[1] = r1; ss[1] = s1; // lower addr second
+
+        vm.expectRevert(abi.encodeWithSelector(BridgeVerifier.DuplicateSigner.selector, vals[0]));
+        verifier.verifyAndDeliver(1, 101, messagesHash, messages, signers, vs, rs, ss);
+    }
+
+    function test_VerifyAndDeliver_SignatureMismatch() public {
+        bytes[] memory messages = new bytes[](1);
+        messages[0] = hex"00";
+        bytes32 messagesHash = keccak256(abi.encode(messages));
+
+        // Sign with pks[0] but claim it's vals[1]
+        (uint8 v0, bytes32 r0, bytes32 s0) = _signCheckpoint(pks[0], 1, 101, messagesHash);
+
+        address[] memory signers = new address[](1);
+        uint8[] memory vs = new uint8[](1);
+        bytes32[] memory rs = new bytes32[](1);
+        bytes32[] memory ss = new bytes32[](1);
+        signers[0] = vals[1]; vs[0] = v0; rs[0] = r0; ss[0] = s0;
+
+        vm.expectRevert(abi.encodeWithSelector(BridgeVerifier.SignatureMismatch.selector, vals[1], vals[0]));
+        verifier.verifyAndDeliver(1, 101, messagesHash, messages, signers, vs, rs, ss);
+    }
+
+    function test_UpdateValidatorSet() public {
+        address val4 = vm.addr(0xDE4D);
+
+        address[] memory newVals = new address[](2);
+        uint256[] memory newPowers = new uint256[](2);
+        // Must be sorted ascending
+        if (vals[0] < val4) {
+            newVals[0] = vals[0]; newPowers[0] = 50;
+            newVals[1] = val4;    newPowers[1] = 30;
+        } else {
+            newVals[0] = val4;    newPowers[0] = 30;
+            newVals[1] = vals[0]; newPowers[1] = 50;
+        }
+
+        // Hash the new validator set
+        bytes memory valsetData = abi.encode(uint256(1), uint256(2));
+        for (uint i = 0; i < newVals.length; i++) {
+            valsetData = abi.encodePacked(valsetData, newVals[i], newPowers[i]);
+        }
+        bytes32 valsetHash = keccak256(valsetData);
+        bytes32 ethHash = keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", valsetHash));
+
+        // Sign with 2/3+ of current set (sorted)
+        uint[] memory idx = new uint[](2);
+        idx[0] = 0; idx[1] = 1;
+        address[] memory signers = new address[](2);
+        uint8[] memory vs = new uint8[](2);
+        bytes32[] memory rs = new bytes32[](2);
+        bytes32[] memory ss = new bytes32[](2);
+        for (uint i = 0; i < 2; i++) {
+            signers[i] = vals[idx[i]];
+            (vs[i], rs[i], ss[i]) = vm.sign(pks[idx[i]], ethHash);
+        }
+
+        verifier.updateValidatorSet(2, newVals, newPowers, signers, vs, rs, ss);
+
+        assertEq(verifier.currentValsetNonce(), 2);
+        assertEq(verifier.totalPower(), 80);
+    }
+
+    function test_MessageDeliveryFailure_DoesNotBlock() public {
+        gateway.setRevert(true);
+
+        bytes[] memory messages = new bytes[](2);
+        messages[0] = hex"000102";
+        messages[1] = hex"030405";
+        bytes32 messagesHash = keccak256(abi.encode(messages));
+
+        uint[] memory idx = new uint[](2);
+        idx[0] = 0; idx[1] = 1;
+        (address[] memory signers, uint8[] memory vs, bytes32[] memory rs, bytes32[] memory ss)
+            = _buildSorted(idx, messagesHash, 1, 101);
+
+        verifier.verifyAndDeliver(1, 101, messagesHash, messages, signers, vs, rs, ss);
+        assertEq(verifier.lastCheckpointNonce(101), 1);
+        assertEq(gateway.getDeliveredCount(), 0);
+    }
+
+    function test_Pause() public {
+        verifier.pause();
+
+        bytes[] memory messages = new bytes[](1);
+        messages[0] = hex"00";
+        bytes32 messagesHash = keccak256(abi.encode(messages));
+
+        uint[] memory idx = new uint[](2);
+        idx[0] = 0; idx[1] = 1;
+        (address[] memory signers, uint8[] memory vs, bytes32[] memory rs, bytes32[] memory ss)
+            = _buildSorted(idx, messagesHash, 1, 101);
+
+        vm.expectRevert("Pausable: paused");
+        verifier.verifyAndDeliver(1, 101, messagesHash, messages, signers, vs, rs, ss);
+
+        verifier.unpause();
+        verifier.verifyAndDeliver(1, 101, messagesHash, messages, signers, vs, rs, ss);
+        assertEq(verifier.lastCheckpointNonce(101), 1);
+    }
+}

--- a/test/foundry/unit/BridgeVerifier.t.sol
+++ b/test/foundry/unit/BridgeVerifier.t.sol
@@ -65,7 +65,7 @@ contract BridgeVerifierTest is Test {
             valsArr[i] = vals[i];
             powersArr[i] = powers[i];
         }
-        verifier.initialize(address(this), address(gateway), valsArr, powersArr);
+        verifier.initialize(address(this), address(gateway), 101, valsArr, powersArr);
     }
 
     function _signCheckpoint(

--- a/test/mocks/ImuachainGatewayMock.sol
+++ b/test/mocks/ImuachainGatewayMock.sol
@@ -360,6 +360,39 @@ contract ImuachainGatewayMock is
         emit MessageExecuted(act, _origin.nonce);
     }
 
+    function oracleReceive(uint32 srcChainId, uint64 nonce, bytes calldata message)
+        external
+        whenNotPaused
+        nonReentrant
+    {
+        if (msg.sender != oracleCaller) {
+            revert Errors.ImuachainGatewayNotOracleCaller();
+        }
+        _validateMessageLength(message);
+
+        Action act = Action(uint8(message[0]));
+        bytes calldata payload = message[1:];
+        bytes4 selector_ = _whiteListFunctionSelectors[act];
+        if (selector_ == bytes4(0)) {
+            revert Errors.UnsupportedRequest(act);
+        }
+
+        (bool success, bytes memory responseOrReason) =
+            address(this).call(abi.encodePacked(selector_, abi.encode(srcChainId, nonce, act, payload)));
+        if (!success) {
+            revert Errors.RequestOrResponseExecuteFailed(act, nonce, responseOrReason);
+        }
+
+        emit OracleReceived(srcChainId, nonce, act);
+    }
+
+    function setOracleCaller(address oracleCaller_) external onlyOwner {
+        if (oracleCaller_ == address(0)) {
+            revert Errors.ZeroAddress();
+        }
+        oracleCaller = oracleCaller_;
+    }
+
     /// @notice Handles LST transfer from a client chain.
     /// @dev Can only be called from this contract via low-level call.
     /// @dev Returns empty bytes if the action is deposit, otherwise returns the lzNonce and success flag.

--- a/test/mocks/ImuachainGatewayMock.sol
+++ b/test/mocks/ImuachainGatewayMock.sol
@@ -368,6 +368,10 @@ contract ImuachainGatewayMock is
         if (msg.sender != oracleCaller) {
             revert Errors.ImuachainGatewayNotOracleCaller();
         }
+        if (processedOracleNonces[srcChainId][nonce]) {
+            revert Errors.DuplicateOracleNonce(srcChainId, nonce);
+        }
+        processedOracleNonces[srcChainId][nonce] = true;
         _validateMessageLength(message);
 
         Action act = Action(uint8(message[0]));
@@ -381,6 +385,13 @@ contract ImuachainGatewayMock is
             address(this).call(abi.encodePacked(selector_, abi.encode(srcChainId, nonce, act, payload)));
         if (!success) {
             revert Errors.RequestOrResponseExecuteFailed(act, nonce, responseOrReason);
+        }
+
+        // Mirror production: emit OutboundResponse when the handler returned a non-empty response.
+        bytes memory response = abi.decode(responseOrReason, (bytes));
+        if (response.length > 0) {
+            bytes memory fullPayload = abi.encodePacked(Action.RESPOND, response);
+            emit OutboundResponse(srcChainId, nonce, fullPayload);
         }
 
         emit OracleReceived(srcChainId, nonce, act);


### PR DESCRIPTION
based on #191 feat/oracle-gateway
## Summary

  Add `BridgeVerifier` contract and outbound oracle bridge support for
  validator-verified cross-chain message delivery (replacing LayerZero for
  the outbound direction).

  ### Trust model

  Client chain trusts messages signed by 2/3+ of imuachain validator voting
  power. Compromised relayer can delay but cannot fabricate (BridgeVerifier
  validates against on-chain validator set, `_handleResponse` validates
  against `_registeredRequests`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added oracle-based cross-chain messaging infrastructure as an alternative transport layer to LayerZero
  * Introduced BridgeVerifier contract for validating signatures and delivering cross-chain messages with validator consensus
  * Extended gateway contracts with oracle receiver and delivery entry points for message routing

* **Configuration**
  * Enabled IR-based Solidity compilation for improved performance optimization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->